### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/validate-markdown.yml
+++ b/.github/workflows/validate-markdown.yml
@@ -1,4 +1,6 @@
 name: Validate markdown
+permissions:
+  contents: read
 
 on:
   pull_request:


### PR DESCRIPTION
Potential fix for [https://github.com/microsoft/agent-academy/security/code-scanning/3](https://github.com/microsoft/agent-academy/security/code-scanning/3)

The best way to fix this problem is to add a `permissions:` block to the root of the workflow YAML file, setting the least required privileges for the `GITHUB_TOKEN`. As the jobs only need to read repository contents (for checking markdown files, links, and spelling), set the permissions to `contents: read`. This can be achieved by inserting the following block immediately after the workflow `name` (top-level, before the `on:`):  
```yaml
permissions:
  contents: read
```
This change ensures all jobs within the workflow inherit these least-privilege permissions, unless overridden. No other changes to steps or imports are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
