### PR TITLE
Potential fix for code scanning alert no. 4: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/add-comment-to-recruit-issues.yml
+++ b/.github/workflows/add-comment-to-recruit-issues.yml
@@ -1,4 +1,6 @@
 name: Add comment to all issues
+permissions:
+  issues: write
 
 on:
   workflow_dispatch:  # Allows manual trigger


### PR DESCRIPTION
Potential fix for [https://github.com/microsoft/agent-academy/security/code-scanning/4](https://github.com/microsoft/agent-academy/security/code-scanning/4)

To fix the issue, add a `permissions` block restricting permissions to only those needed by the workflow. In this case, the workflow uses the GitHub REST API to comment on issues, so it requires `issues: write` permission. You can add this permission either at the root of the workflow file (so it applies to all jobs) or specifically within the `add_comments` job. Best practice is to place it at the root if the workflow will only ever handle issues, but per-job is clearer if you expect to add jobs with different needs. Edit `.github/workflows/add-comment-to-recruit-issues.yml` and add the following lines immediately after the `name` key, before the `on:` block:

```yaml
permissions:
  issues: write
```

No new imports, methods, or special definitions are needed.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
