### PR TITLE
Updates to docs\operative-preview

### DIFF
--- a/docs/operative-preview/05-model-selection/README.md
+++ b/docs/operative-preview/05-model-selection/README.md
@@ -44,7 +44,7 @@ Different models are designed for specific tasks. Selecting the right model impr
 The table below outlines model tags, their strengths, and key considerations - [source](https://learn.microsoft.com/en-us/microsoft-copilot-studio/authoring-select-agent-model#model-use-categories).
 
 | Tag | Description | Strengths | Latency | Cost | Reasoning depth |
-|-------|----------|----------|-------------|-----------|-----------|
+| ------- | ---------- | ---------- | ------------- | ----------- | ----------- |
 | **Deep** | Optimized for deliberate, multi-step reasoning and tool-supported workflows. | Complex analytics, multi-hop reasoning, policy and contract analysis, troubleshooting with multi-system steps, and synthesis of long documents with citations | Highest | Highest | Multi-step, tool-rich |
 | **Auto** | Optimized for coverage across mixed workloads; routes queries dynamically. | Helpdesk and employee agents with mixed intents, blending knowledge and actions, and tier‑0 customer support with unpredictable complexity | Variable | Variable | Multi-step, tool-rich |
 | **General** | Optimized for speed and cost on everyday chat and light grounding. | Drafting, rewriting, summarizing, and translation, FAQ-style grounded answers, and simple action automation | Lowest | Lowest | Shallow-to-moderate |
@@ -56,7 +56,7 @@ Models are released in stages. You can explore cutting-edge options like Experim
 The table below explains the availability tags - [source](https://learn.microsoft.com/en-us/microsoft-copilot-studio/authoring-select-agent-model#model-use-categories).
 
 | Tag | Description |
-|-----|-------------|
+| ----- | ------------- |
 | **Experimental** | Used for experimentation, and not recommended for production use. Subject to preview terms, and can have limitations on availability and quality. See [Limitations of experimental and preview models.](https://learn.microsoft.com/en-us/microsoft-copilot-studio/authoring-select-agent-model#limitations-of-experimental-and-preview-models) |
 | **Preview** | Will eventually become a generally available model, but currently not recommended for production use. Subject to preview terms, and can have limitations on availability and quality. See [Limitations of experimental and preview models.](https://learn.microsoft.com/en-us/microsoft-copilot-studio/authoring-select-agent-model#limitations-of-experimental-and-preview-models) |
 | **No tag** | Generally available. You can use this model for scaled and production use. In most cases, generally available models have no limitations on availability and quality, but some might still have some limitations, like regional availability. |
@@ -68,7 +68,7 @@ The table below explains the availability tags - [source](https://learn.microsof
 AI capabilities evolve rapidly, and Copilot Studio keeps up by offering a range of Azure OpenAI models. As of 2025, the primary models to choose from include OpenAI's GPT-4.1, and the latest GPT-5 previews. The following table summarizes the main choices and what each is best suited for:
 
 | Model Version | Category | Availability | Key Strengths | Ideal Use Cases |
-|-------|----------|----------|-------------|-----------|
+| ------- | ---------- | ---------- | ------------- | ----------- |
 | **GPT‑4o** | General | Retired | Fast, versatile responses; supports text and image input; cost-effective balance of speed and accuracy. | Routine Q&A; summarizing support chats or calls; quick content drafts; tasks combining text with visuals. |
 | **GPT-4.1** | General | Default | Higher accuracy and reasoning than GPT-4o; excellent at complex text analysis (text-only model). | Analyzing detailed documents (policies, reports); complex knowledge-base Q&A; scenarios where precision is critical. |
 | **GPT‑5 Chat** | General | Preview | Advanced conversational abilities with strong context retention; produces human-like dialogue. | Employee self-service chatbots; IT/HR helpdesk assistants; interactive agents requiring natural, human-like responses. |
@@ -94,7 +94,7 @@ OpenAI remains as the default model for new agents in Copilot Studio and you hav
 Both are available in Microsoft Copilot Studio as opt-in preview (Frontier Program) models rather than General Availability (GA), meaning they’re for early experimental use only. The table below compares their status, strengths, and ideal use cases in the Copilot Studio context:
 
 | Model Version | Status | Key Strengths | Ideal Use Cases |
-|-------|----------|-------------|-----------|
+| ------- | ---------- | ------------- | ----------- |
 | **Claude Sonnet 4.5** | Experimental | Excels at code-related tasks and complex “agent” workflows; strong at tool use and step-by-step reasoning. | Advanced software development assistance (code generation & debugging); building multi-step autonomous agents; tasks requiring integration with external tools or systems. |
 | **Claude Opus 4.1** | Experimental | Specialized for intensive analysis and structured problem-solving. | In-depth data analysis and research projects; complex reasoning scenarios (e.g. compliance auditing, elaborate planning) where thoroughness is paramount. |
 
@@ -183,7 +183,7 @@ These admin settings ensure that **organizations stay in control** of sensitive 
 For a quick reference, here’s a summary of the admin controls related to model selection:
 
 | Admin Setting | Effect on Model selection | Setting location |
-|----------|------------|------------|
+| ---------- | ------------ | ------------ |
 | **Allow Anthropic models** | When **Allowed**, users can connect to the Anthropic external models for agents built in Copilot Studio. When **disabled**, only OpenAI models are available. | Microsoft 365 Admin Center |
 | **Allow Preview & Experimental Models** | When **ON**, makers can choose preview/experimental AI models (for example GPT-5 Chat) for their agents. When **OFF**, only production-ready models are available. | Power Platform admin center |
 | **Move Data Across Regions** | Required to be **ON** if experimental models are enabled. It permits data from the agent to be processed and stored outside the home region. If this is OFF, any model that would require cross-region data flow will be blocked, leading to the agent's generative AI features being unavailable. Managed in the Power Platform admin centre by a tenant administrator. | Power Platform admin center |
@@ -216,8 +216,8 @@ In Copilot Studio’s generative answer node, you can allow or disallow certain 
 
 Copilot Studio generative answers support a subset of Markdown for rich text. Here are the main formatting elements you can leverage in the AI’s responses, and what they do:
 
-| Formatting Option | Purpose and Effect  | Example Usage |
-|----------|------------|---------|
+| Formatting Option | Purpose and Effect | Example Usage |
+| ---------- | ------------ | --------- |
 | **Bold** | Makes important words or phrases stand out. Use bold to highlight key information or critical values. | **"Your account balance is $1,250."** - The amount is bold so it's immediately noticeable. |
 | _Italics_ | Adds subtle emphasis or denotes special terms. Commonly used for document titles, or to highlight a _phrase_ in a softer way than bold. | _"Please provide additional details for verification."_ - The words “additional details” are italicized to indicate a prompt or placeholder. |
 | Hyperlinks | Inserts clickable links in the response text. Useful for directing users to external articles, internal knowledge base, or any detailed reference. | "Refer to our [Microsoft Surface Warranty and Protection Plans](https://www.microsoft.com/surface/business/warranty-protection-plans-and-support) for more details." - The text "Microsoft Surface Warranty and Protection Plans" is a hyperlink to the web page. |

--- a/docs/operative-preview/08-dataverse-grounding/README.md
+++ b/docs/operative-preview/08-dataverse-grounding/README.md
@@ -76,7 +76,7 @@ By adding Dataverse grounding, your Summarize Resume flow will:
 
 ## 🎯 Why dedicated prompts vs agent conversations
 
-In Mission 02, you experienced how the Interview Agent could match candidates to job roles, but required complex user prompts like:
+In Mission 03, you experienced how the Interview Agent could match candidates to job roles, but required complex user prompts like:
 
 ```text
 Upload this resume, then show me open job roles,
@@ -90,7 +90,7 @@ While this worked, dedicated prompts with Dataverse grounding offer significant 
 ### Key advantages of dedicated prompts
 
 | Aspect | Agent Conversations | Dedicated Prompts |
-|--------|-------------------|------------------|
+| -------- | ------------------- | ------------------ |
 | **Consistency** | Results vary based on user's prompt crafting skills | Standardized processing every time |
 | **Specialization** | General-purpose reasoning may miss business nuances | Purpose-built with optimized business logic |
 | **Automation** | Requires human interaction and interpretation | Triggers automatically with structured JSON output |
@@ -133,7 +133,7 @@ First, let's examine the Dataverse tables you'll be grounding with:
 1. Review the key columns you'll use for grounding:
 
     | Column | Purpose |
-    |--------|---------|
+    | -------- | --------- |
     | **Job Role Number** | Unique identifier for role matching |
     | **Job Title** | Display name for the role |
     | **Description** | Detailed role requirements |
@@ -269,9 +269,9 @@ To allow our Application Intake Agent to create Job Roles based on the suggested
 
 1. Select the **When an agent calls the flow** node, use **+ Add an input** to add the following parameter:
 
-    | Type | Name            | Description                                                  |
-    | ---- | --------------- | ------------------------------------------------------------ |
-    | Text | `ResumeNumber`  | Be sure to only use the [ResumeNumber] - it MUST start with the letter R |
+    | Type | Name            | Description                                                               |
+    | ---- | --------------- | ------------------------------------------------------------------------- |
+    | Text | `ResumeNumber`  | Be sure to only use the [ResumeNumber] - it MUST start with the letter R  |
     | Text | `JobRoleNumber` | Be sure to only use the [JobRoleNumber] - it MUST start with the letter J |
 
     ![When an agent calls the flow](./assets/8-add-application-1.png)
@@ -280,11 +280,11 @@ To allow our Application Intake Agent to create Job Roles based on the suggested
 
 1. **Rename** the node as `Get Resume`, and then set the following parameters:
 
-    | Property        | How to Set                      | Value                                                        |
-    | --------------- | ------------------------------- | ------------------------------------------------------------ |
-    | **Table name**  | Select                          | Resumes                                                      |
+    | Property        | How to Set                      | Value                                                                                                                             |
+    | --------------- | ------------------------------- | --------------------------------------------------------------------------------------------------------------------------------- |
+    | **Table name**  | Select                          | Resumes                                                                                                                           |
     | **Filter rows** | Dynamic data (thunderbolt icon) | `ppa_resumenumber eq 'ResumeNumber'` Select and replace **ResumeNumber** with **When an agent calls the flow** → **ResumeNumber** |
-    | **Row count**   | Enter                           | 1                                                            |
+    | **Row count**   | Enter                           | 1                                                                                                                                 |
 
     ![Get Resume](./assets/8-add-application-2.png)
 
@@ -292,11 +292,11 @@ To allow our Application Intake Agent to create Job Roles based on the suggested
 
 1. **Rename** the node as `Get Job Role`, and then set the following parameters:
 
-    | Property        | How to Set                      | Value                                                        |
-    | --------------- | ------------------------------- | ------------------------------------------------------------ |
-    | **Table name**  | Select                          | Job Roles                                                    |
+    | Property        | How to Set                      | Value                                                                                                                                 |
+    | --------------- | ------------------------------- | ------------------------------------------------------------------------------------------------------------------------------------- |
+    | **Table name**  | Select                          | Job Roles                                                                                                                             |
     | **Filter rows** | Dynamic data (thunderbolt icon) | `ppa_jobrolenumber eq 'JobRoleNumber'` Select and replace **JobRoleNumber** with **When an agent calls the flow** → **JobRoleNumber** |
-    | **Row count**   | Enter                           | 1                                                            |
+    | **Row count**   | Enter                           | 1                                                                                                                                     |
 
     ![Get Job Role](./assets/8-add-application-3.png)
 
@@ -304,24 +304,24 @@ To allow our Application Intake Agent to create Job Roles based on the suggested
 
 1. **Rename** the node as `Add Application`, and then set the following parameters:
 
-    | Property                           | How to Set           | Value                                                        |
-    | ---------------------------------- | -------------------- | ------------------------------------------------------------ |
-    | **Table name**                     | Select               | Job Applications                                             |
-    | **Candidate (Candidates)**             | Expression (fx icon) | `concat('ppa_candidates/',first(outputs('Get_Resume')?['body/value'])?['_ppa_candidate_value'])` |
-    | **Job Role (Job Roles)**               | Expression (fx icon) | `concat('ppa_jobroles/',first(outputs('Get_Job_Role')?['body/value'])?['ppa_jobroleid'])` |
-    | **Resume (Resumes)**                   | Expression (fx icon) | `concat('ppa_resumes/', first(outputs('Get_Resume')?['body/value'])?['ppa_resumeid'])` |
-    | **Application Date** (use **Show all**) | Expression (fx icon) | `utcNow()`                                                   |
+    | Property                                | How to Set           | Value                                                                                            |
+    | ----------------------------------      | -------------------- | ------------------------------------------------------------------------------------------------ |
+    | **Table name**                          | Select               | Job Applications                                                                                 |
+    | **Candidate (Candidates)**              | Expression (fx icon) | `concat('ppa_candidates/',first(outputs('Get_Resume')?['body/value'])?['_ppa_candidate_value'])` |
+    | **Job Role (Job Roles)**                | Expression (fx icon) | `concat('ppa_jobroles/',first(outputs('Get_Job_Role')?['body/value'])?['ppa_jobroleid'])`        |
+    | **Resume (Resumes)**                    | Expression (fx icon) | `concat('ppa_resumes/', first(outputs('Get_Resume')?['body/value'])?['ppa_resumeid'])`           |
+    | **Application Date** (use **Show all**) | Expression (fx icon) | `utcNow()`                                                                                       |
 
     ![Add Application](./assets/8-add-application-4.png)
 
 1. Select the **Respond to the agent node**, and then select **+ Add an output**
 
-     | Property        | How to Set                      | Details                                         |
-     | --------------- | ------------------------------- | ----------------------------------------------- |
-     | **Type**        | Select                          | `Text`                                          |
-     | **Name**        | Enter                           | `ApplicationNumber`                             |
-     | **Value**       | Dynamic data (thunderbolt icon) | *Add Application → See More → Application Number* |
-     | **Description** | Enter                           | `The [ApplicationNumber] of the Job Application created`      |
+     | Property        | How to Set                      | Details                                                  |
+     | --------------- | ------------------------------- | -------------------------------------------------------- |
+     | **Type**        | Select                          | `Text`                                                   |
+     | **Name**        | Enter                           | `ApplicationNumber`                                      |
+     | **Value**       | Dynamic data (thunderbolt icon) | *Add Application → See More → Application Number*        |
+     | **Description** | Enter                           | `The [ApplicationNumber] of the Job Application created` |
 
      ![Respond to the agent](./assets/8-add-application-5.png)
 
@@ -347,10 +347,10 @@ Now you'll connect the published flow to your Application Intake Agent.
 
 1. Set the following parameters:
 
-    | Parameter                                           | Value                                                        |
-    | --------------------------------------------------- | ------------------------------------------------------------ |
+    | Parameter                                           | Value                                                                         |
+    | --------------------------------------------------- | ----------------------------------------------------------------------------- |
     | **Description**                                     | `Creates a new job application when given [ResumeNumber] and [JobRoleNumber]` |
-    | **Additional details → When this tool may be used** | `Only when referenced by topics or agents`                   |
+    | **Additional details → When this tool may be used** | `Only when referenced by topics or agents`                                    |
 
 1. Select **Save**  
     ![Add Agent Flow to Agent](./assets/8-add-application-6.png)

--- a/docs/operative-preview/11-obtain-user-feedback/README.md
+++ b/docs/operative-preview/11-obtain-user-feedback/README.md
@@ -155,9 +155,9 @@ In summary, Adaptive Cards for feedback are ideal when you need more than a bina
 
 Both feedback collection methods aim to improve your Copilot agent via user input, but they serve different needs. Here's a side-by-side comparison to help understand when to use each:
 
-| Feature/aspect | Built-in thumbs up/down reactions  | Custom feedback via Adaptive Card |
-|----------|------------|---------|
-| **Setup and effort** | Zero setup required - enabled by default for all agents. Simply deploy your agent, and users will see 👍🏻/👎🏻 on each response. | Requires configuration: you must add an Adaptive Card node to your topics and define its JSON, then handle the submitted data. Moderate effort for developers.  |
+| Feature/aspect | Built-in thumbs up/down reactions | Custom feedback via Adaptive Card |
+| ---------- | ------------ | --------- |
+| **Setup and effort** | Zero setup required - enabled by default for all agents. Simply deploy your agent, and users will see 👍🏻/👎🏻 on each response. | Requires configuration: you must add an Adaptive Card node to your topics and define its JSON, then handle the submitted data. Moderate effort for developers. |
 | **Feedback format** | Binary sentiment (Positive or Negative). Users can optionally add a text comment with their rating | Fully customizable. Could be binary as well, or multi-choice, rating scale, text input, or any combination. The card's JSON defines the format |
 | **User experience** | Simple and unobtrusive: one click for thumbs up/down. The option is presented uniformly on all channels (icon buttons). | Potential for richer interaction, but if overused can be intrusive. You control the wording and look. Make sure the card is concise so it doesn't overwhelm the chat UI |
 | **Data captured** | Reaction (+ optional comment). Example: `"thumbs down (with comment: 'irrelevant answer')"`. No structured category beyond up/down. | Whatever data you design. Example: you might capture `"Rating: 3 stars"` or `"FeedbackChoice: NotUseful + Reason: Outdated info"`. The card submission is received as a JSON payload (key-value pairs) which you can parse |
@@ -174,7 +174,7 @@ Ultimately, for most scenarios using one method at a time is clearer. If you opt
 ## 🎀 Wrapping it up (summary)
 
 | ⚡ **Built-in reactions: quick wins** | 🛠️ **Adaptive cards: custom fit** |
-|------------|------------|
+| ------------ | ------------ |
 | Enable built-in 👍🏻/👎🏻 reactions to rapidly gauge user satisfaction on each answer. This yields instant analytics (no coding) and helps identify trouble spots early. | Use adaptive cards for feedback when you need more than a `yes/no`. You can ask tailored questions and route feedback into your own data stores or workflows for deeper analysis and action. |
 
 ## 🧪 Lab 11 - Provide feedback using built-in interactions vs adaptive cards (custom)
@@ -695,8 +695,11 @@ Congratulations! 👏🏻 Excellent work, Operative.
 
 In this final mission, you’ve learned how to close the feedback loop for your agents:
 
-✅ Built-in feedback: you learned how to provide user feedback and where to review the feedback analytics..
-✅ Adaptive cards (custom): you learned how to collect feedback using an adaptive card and log telemetry to Azure Application Insights.
+**✅ Built-in feedback**
+You learned how to provide user feedback and where to review the feedback analytics.
+
+**✅ Adaptive cards (custom)**
+You learned how to collect feedback using an adaptive card and log telemetry to Azure Application Insights.
 
 Feedback is paramount to iterative improvements to your agents! It's not optional. It's how good agents become great ones.
 
@@ -711,7 +714,7 @@ We won’t walk you through publishing again here as you already mastered that s
 - Start collecting feedback
 - Iterate
 
-If you need a refresher, revisit the [Recruit publishing module](https://microsoft.github.io/agent-academy/recruit/11-publish-your-agent/) then come right back and finish strong.
+If you need a refresher, revisit the [Recruit publishing module](../../recruit/11-publish-your-agent/README.md) then come right back and finish strong.
 
 > [!IMPORTANT]
 > If you are using a trial license to complete the course, you will not be able to publish.Publishing is not required to get a badge for this lab.

--- a/docs/operative-preview/README.md
+++ b/docs/operative-preview/README.md
@@ -51,12 +51,12 @@ This advanced course is ideal for:
 This academy is structured as a progressive series of field operations—each mission builds upon the previous to create a comprehensive hiring automation system.
 
 | Mission | Title | Operation Briefing |
-|---------|-------|-------------------|
+| --------- | ------- | ------------------- |
 | `01` | 🚨 [Get started with the Hiring Agent](./01-get-started/README.md) | Deploy foundational infrastructure and create your central orchestrator agent |
 | `02` | 📝 [Authoring Agent Instructions](./02-agent-instructions/README.md) | Master precise agent communication and behavior control |
 | `03` | 🎭 [Make your agent multi-agent ready with connected agents](./03-multi-agent/README.md) | Transform single agent into coordinated multi-agent system |
 | `04` | ⚡ [Automate your agent with Triggers](./04-automate-triggers/README.md) | Implement autonomous agent behaviors with event-driven triggers |
-| `05` | 💬 [Understanding Agent Models](./05-agent-responses/README.md) | Customize agent models for maximum impact and engagement |
+| `05` | 💬 [Understanding Agent Models](./05-model-selection/README.md) | Customize agent models for maximum impact and engagement |
 | `06` | 🛡️ [Content Moderation and AI Safety Essentials](./06-ai-safety/README.md) | Implement enterprise-grade safety and compliance measures |
 | `07` | 🎨 [Extracting Resume Contents with Multi-Modal Prompts](./07-multimodal-prompts/README.md) | Process documents and images with advanced AI capabilities |
 | `08` | 🗄️ [Prompts - Dataverse Grounding](./08-dataverse-grounding/README.md) | Ground agents in enterprise data for accurate responses |


### PR DESCRIPTION
Updated docs\operative-preview\README.md
- Fixed table markdown formatting that was showing up in the VSC Problems tab
- Updated table of contents to correctly reference the updated Mission 05 name

Updated docs\operative-preview\05-model-selection\README.md
- Fixed table markdown formatting that was showing up in the VSC Problems tab

Updated docs\operative-preview\08-dataverse-grounding\README.md
- Fixed table markdown formatting that was showing up in the VSC Problems tab

Updated docs\operative-preview\11-obtain-user-feedback\README.md
- Fixed table markdown formatting that was showing up in the VSC Problems tab
- Removed direct https:// URL reference to Recruit - Mission 11 and replaced with GitHub path reference