### PR TITLE
Fix parameter descriptions in automation triggers doc

### DIFF
--- a/docs/operative/04-automate-triggers/index.md
+++ b/docs/operative/04-automate-triggers/index.md
@@ -661,8 +661,8 @@ Let's begin!
     |----------|------------|---------|
     | **Post as** | Dropdown | Select the `Flow bot` option |
     | **Post in** | Dropdown | Select the `Channel` option |
+    | **Channel** | Dropdown | Select a channel that's available in your environment that you have access to for the purpose of completing this lab exercise |
     | **Team** | Dropdown | Select a team that's available in your environment that you have access to for the purpose of completing this lab exercise |
-    | **Team** | Dropdown | Select a channel that's available in your environment that you have access to for the purpose of completing this lab exercise |
 
     ![Configure input parameters](assets/3.2_14_ConfigureParameters.png)
 


### PR DESCRIPTION
There were two Teams, one should have been named Channel.