### PR TITLE
fix(mission-05): remove outdated 'Enable generative AI' step

### DIFF
--- a/docs/recruit/05-using-prebuilt-agents/index.md
+++ b/docs/recruit/05-using-prebuilt-agents/index.md
@@ -86,10 +86,6 @@ This will create a new agent in your environment based on the Safe Travels confi
 
 Now that the agent is created, let’s tailor it to your organization:
 
-1. Select **Enabled generative AI** to turn on the generative AI feature so that it can use the instructions provided in the template.
-
-    ![Enable Generative Answers](./images/gen-answers.png)
-
 1. Now we'll equip the agent with an additional knowledge source so it can answer questions about Europe travel. To do this, scroll down to the **knowledge** section and select **Add knowledge**
 
     ![Add Knowledge](./images/knowledge.png)


### PR DESCRIPTION
The **Enable generative AI** toggle referenced in step 5.3 no longer exists in Copilot Studio. Agents created from templates have generative AI enabled automatically — there's no manual step required.

This removes the outdated instruction and its associated screenshot reference, which was causing confusion for users following Mission 05.

Fixes #1780