### PR TITLE
Change 'Always allow' to 'Allow' in instructions

### DIFF
--- a/docs/recruit/03-create-a-declarative-agent-for-M365Copilot/index.md
+++ b/docs/recruit/03-create-a-declarative-agent-for-M365Copilot/index.md
@@ -524,7 +524,7 @@ Let's now publish our declarative agent 😃
 
     ![Select one of suggested prompts](assets/3.4_08_SelectStarterPrompt.png)
 
-1. Select **Always allow** to give your declarative agent permission to invoke the IT Expert prompt.
+1. Select **Allow** to give your declarative agent permission to invoke the IT Expert prompt.
 
     ![Select always allow](assets/3.4_09_AlwaysAllow.png)
 


### PR DESCRIPTION
Changed "Always Allow" to "Allow" on 527 to reflect the dialog presented in the agent's UI.