### PR TITLE
Fix VitePress dead link to Operative training page

### DIFF
--- a/docs/recruit/course-completion-badges-recruit/index.md
+++ b/docs/recruit/course-completion-badges-recruit/index.md
@@ -153,7 +153,7 @@ More missions are coming.
 🎖 Congratulations, Recruit.  
 You didn’t just watch content—you *built something*.
 
-Next up: **[Operative training](../../operative)**.
+Next up: **[Operative training](../../operative/)**.
 
 ## 📚 Tactical Resources
 


### PR DESCRIPTION
## Summary
Fix VitePress build failure caused by a dead link in the recruit badge completion page.

## Build Error
```
(!) Found dead link ./../../operative in file recruit/course-completion-badges-recruit/index.md
✗ Build failed in 15.04s
[vitepress] 1 dead link(s) found.
```

## Changes
- `docs/recruit/course-completion-badges-recruit/index.md`
  - `../../operative` → `../../operative/` (add trailing slash)

VitePress router cannot resolve directory references without a trailing slash.
This aligns with the existing convention in `config.mts` nav links (`/operative/`).