### PR TITLE
fix: bump lodash-es to 4.18.1 (CVE-2021-23337)

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -2885,9 +2885,9 @@
       }
     },
     "node_modules/lodash-es": {
-      "version": "4.17.23",
-      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.17.23.tgz",
-      "integrity": "sha512-kVI48u3PZr38HdYz98UmfPnXl2DXrpdctLrFLCd3kOx1xUkOmpFPx7gCWWM5MPkL/fD8zb+Ph0QzjGFs4+hHWg==",
+      "version": "4.18.1",
+      "resolved": "https://registry.npmjs.org/lodash-es/-/lodash-es-4.18.1.tgz",
+      "integrity": "sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==",
       "dev": true,
       "license": "MIT"
     },

--- a/package.json
+++ b/package.json
@@ -15,5 +15,8 @@
   },
   "dependencies": {
     "mermaid": "^11.12.3"
+  },
+  "overrides": {
+    "lodash-es": "^4.18.1"
   }
 }


### PR DESCRIPTION
Fixes the Dependabot alert: **lodash vulnerable to Code Injection via `_.template` imports key names** (CVE-2021-23337).

`lodash-es` is a transitive dependency pulled in by `mermaid` and cannot be upgraded directly via `npm audit fix`. This PR adds an `overrides` entry in `package.json` to force `lodash-es` to `^4.18.1` across the entire dependency tree.

**Verified:** `npm audit` reports 0 vulnerabilities after the change.