### PR TITLE
Add agent-academy-report skill

### DIFF
--- a/.github/skills/agent-academy-report/SKILL.md
+++ b/.github/skills/agent-academy-report/SKILL.md
@@ -1,0 +1,270 @@
+---
+name: agent-academy-report
+description: "Generate a full Agent Academy feedback report — extracting feedback from Excel files and GitHub issues, analyzing sentiment, generating charts, and producing a single styled PDF with a cover page, management summary, and detailed analysis. Use this skill when the user asks to generate an Agent Academy report, create a feedback analysis, build a course completion report, or wants to analyze Agent Academy survey data. Also triggers when the user mentions Agent Academy feedback, course grades, sentiment analysis of Agent Academy data, or exporting Agent Academy results to PDF."
+---
+
+# Agent Academy Report Generator
+
+Generate a comprehensive feedback analysis report for Agent Academy. The report combines data from Excel survey exports and GitHub issues, analyzes sentiment, generates charts, and produces a single styled PDF.
+
+## Folder Structure
+
+The workspace folder should be organized as follows:
+
+```
+<workspace>/report/
+├── data/            ← Excel files (.xlsx) with survey responses
+├── badges/          ← Badge PNG images (downloaded from GitHub)
+├── charts/          ← Generated chart PNG images (output)
+├── markdown/        ← Generated markdown files (output)
+└── pdf/             ← Generated PDF files (output)
+```
+
+If the user provides a workspace path, use it. Otherwise, ask for it.
+
+## Overview
+
+The report generation has 5 phases:
+
+1. **Extract feedback** from Excel files and GitHub issues
+2. **Analyze sentiment** using keyword-based scoring
+3. **Generate charts** with matplotlib
+4. **Build markdown** files (management summary + detailed analysis)
+5. **Export a single PDF** with cover page, management summary, and full analysis
+
+Run the bundled Python scripts in order. Each script is self-contained and reads/writes to the folder structure above.
+
+---
+
+## Phase 1: Extract Feedback
+
+Run `scripts/extract_feedback.py`:
+
+```bash
+python3 <skill-path>/scripts/extract_feedback.py "<workspace-path>/report"
+```
+
+This script:
+- Reads all `.xlsx` files from `<workspace>/report/data/`
+- Maps filenames to human-readable course names
+- Extracts feedback text, completion dates, and respondent names/emails
+- For files without a feedback column (Operative, Recruit), it extracts completion dates only — their feedback comes from GitHub issues
+- Outputs `<workspace>/report/data/_extracted.json`
+
+### GitHub Issues (Operative & Recruit)
+
+After running the extract script, fetch feedback from GitHub issues. **Do not use `mcp_github_mcp_search_issues`** — the search API caps results at 1,000, which is insufficient for Recruit (1,390+ issues). Instead, use `mcp_github_mcp_list_issues` which supports full GraphQL cursor pagination:
+
+**Recruit issues:**
+```
+owner: "microsoft", repo: "agent-academy", labels: ["recruit-completed"], state: "all", perPage: 100
+```
+
+**Operative issues:**
+```
+owner: "microsoft", repo: "agent-academy", labels: ["operative-completed"], state: "all", perPage: 100
+```
+
+Paginate through **all** pages using the `endCursor` from each response until `hasNextPage` is false. The API returns max 100 per page — Recruit requires ~14 pages, Operative ~4 pages. Do not stop early; collect every issue.
+
+For each issue, parse the body for structured sections:
+- `### Key Learnings and Takeaways`
+- `### Challenges Faced`
+- `### Final Thoughts`
+
+Combine these sections as the feedback text. The `name` field should be a plain string (the GitHub username) — if the API returns a `user` object like `{"login": "username"}`, extract just the `login` value.
+
+Save the combined data (Excel + GitHub) to `<workspace>/report/data/_all_feedback.json`.
+
+Each record should have: `{course, date, month, sentiment, text, name, type}`.
+
+---
+
+## Phase 2: Analyze Sentiment
+
+Run `scripts/analyze_sentiment.py`:
+
+```bash
+python3 <skill-path>/scripts/analyze_sentiment.py "<workspace-path>/report"
+```
+
+This script:
+- Reads `<workspace>/report/data/_all_feedback.json`
+- Scores each feedback item using keyword-based sentiment analysis
+- Detects common themes (Hands-on Learning, Setup Challenges, MCP Skills, etc.)
+- Computes per-course grades using weighted average (positive=10, neutral=6, negative=2)
+- Outputs `<workspace>/report/data/_analyzed.json` with sentiment labels, themes, and course stats
+
+### Sentiment Keywords
+
+**Positive** patterns include: great, excellent, amazing, awesome, helpful, useful, learned, clear, intuitive, practical, hands-on, well-structured, engaging, valuable, insightful, comprehensive, etc.
+
+**Negative** patterns include: error, issue, problem, bug, broke, crash, fail, stuck, struggle, missing, trouble, difficult, confusing, frustrating, unclear, improve, wish, lack, disappoint, etc.
+
+**Scoring rule:** If negative matches > positive matches → negative. Else if positive > 0 → positive. Else if negative > 0 → negative. Else → neutral.
+
+---
+
+## Phase 3: Generate Charts
+
+Run `scripts/generate_charts.py`:
+
+```bash
+python3 <skill-path>/scripts/generate_charts.py "<workspace-path>/report"
+```
+
+Requires `matplotlib` and `numpy`. Install if needed: `pip3 install matplotlib numpy`.
+
+This generates 6 charts in `<workspace>/report/charts/` at 180 DPI:
+
+| Chart | Filename | Description |
+|-------|----------|-------------|
+| Weekly completions | `completions_over_time.png` | Stacked area chart by course group |
+| Sentiment by course | `sentiment_by_course.png` | Horizontal stacked bar with positive/negative % labels |
+| Course grades | `grades_by_course.png` | Lollipop chart sorted by grade (best → worst) |
+| Cumulative completions | `cumulative_completions.png` | Line chart with gradient fills and endpoint markers |
+| Overall sentiment | `sentiment_pie.png` | Donut chart with total count in center |
+| Monthly feedback volume | `monthly_feedback.png` | Stacked bar by month and course group |
+
+Color scheme (navy/teal theme matching cover): Blue (#3b82f6), Green (#22c55e), Red (#ef4444), Orange (#f59e0b), Purple (#a78bfa), Teal (#14b8a6). Charts use a consistent light background (#fafbfc), subtle grid (#e2e8f0), and navy (#111827) text.
+
+---
+
+## Phase 4: Build Markdown
+
+Run `scripts/build_markdown.py`:
+
+```bash
+python3 <skill-path>/scripts/build_markdown.py "<workspace-path>/report"
+```
+
+This generates three markdown files in `<workspace>/report/markdown/`:
+
+### management-summary.md
+- Title: "Management Summary"
+- Key metrics table (total completions, feedback count, courses, overall grade, sentiment percentages)
+- Highlights section
+- Chart references (one per section with narrative text)
+- **Course Spotlights** section — for each course:
+  - Grade, response count, positive/negative percentages
+  - Grade explanation (contextual note based on score range)
+  - Top 3 themes with mention counts
+  - Standout/watch area callout for notably high positive or negative rates
+  - Representative quotes — 5 total, split proportionally to the grade (e.g., grade 9.1 → 5 positive, 0 negative; grade 7.7 → 4 positive, 1 negative)
+- Recommendations section
+
+### feedback-analysis.md
+- Title: "Detailed Feedback Analysis"
+- Overall summary table (sentiment counts + percentages)
+- Course overview table (responses, sentiment breakdown, grade per course)
+- Per-course sections with:
+  - Response counts and sentiment percentages
+  - Common themes (positive and negative)
+  - Individual feedback items sorted positive → neutral → negative
+  - Each item as a blockquote with sentiment emoji, quoted text, and attribution
+  - Horizontal rules between items
+
+### feedback.md
+- Curated positive-only feedback (excludes error-mentioning entries)
+- Each item as a blockquote: `> 👍 "text" — Name (Course)`
+
+---
+
+## Phase 5: Export PDF
+
+Run `scripts/export_pdf.py`:
+
+```bash
+python3 <skill-path>/scripts/export_pdf.py "<workspace-path>/report" "<report-title>"
+```
+
+Example: `python3 scripts/export_pdf.py "/path/to/workspace/report" "Agent Academy - Report April 2026"`
+
+This script:
+1. Downloads badge images from `https://raw.githubusercontent.com/microsoft/agent-academy/main/docs/public/images/` to `<workspace>/report/badges/` (if not already present)
+2. Builds a single HTML file with:
+   - **Cover page**: Blue gradient background, Agent Academy logo, report title, all badge images
+   - **Management summary**: Converted from markdown with charts embedded as base64 images
+   - **Detailed analysis**: Full feedback analysis with all blockquotes and tables
+3. Exports to PDF using headless Microsoft Edge:
+   ```bash
+   "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge" \
+     --headless --disable-gpu --no-sandbox \
+     --print-to-pdf="<workspace>/report/pdf/<title>.pdf" \
+     --no-pdf-header-footer \
+     "file://<workspace>/report/_report.html"
+   ```
+4. Cleans up the temporary HTML file
+5. On macOS, automatically removes the `com.apple.quarantine` extended attribute so the PDF opens without a Gatekeeper warning
+
+The output PDF lands in `<workspace>/report/pdf/`.
+
+### Page Break Rules
+
+The HTML includes CSS rules to prevent content from splitting across pages:
+- Charts + their descriptions are wrapped in `.chart-block` divs with `page-break-inside: avoid`
+- Course spotlight sections (h3 + content) are wrapped in `.course-spotlight` divs
+- Headings (`h2`, `h3`, `h4`) use `page-break-after: avoid`
+- Tables, blockquotes, and images all have `page-break-inside: avoid`
+
+### Badge Images
+
+Downloaded from `microsoft/agent-academy` repo at `docs/public/images/`:
+- `logo.png` — Cover page logo
+- `mcs-agent-academy-recruit-badge.png`, `mcs-agent-academy-operative-badge.png`, `mcs-agent-academy-commander-badge.png` — Level badges
+- `YAML_Specialist_Badge.png`, `Academy_LearnMCP_Badge.png`, `CommandLine_Badge.png` — Special Ops badges
+- `BadgeBandit-badge.png`, `AuditAce-badge.png`, `Vacay-badge.png`, `MCP_Joker_Badge.png` — Cowork Collective badges
+
+### Edge Fallback
+
+If Microsoft Edge is not available at the default macOS path, check:
+- `/usr/bin/microsoft-edge` (Linux)
+- `C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe` (Windows)
+- Google Chrome as an alternative (`/Applications/Google Chrome.app/Contents/MacOS/Google Chrome`)
+
+---
+
+## Course Name Mapping
+
+Excel filenames map to display names as follows:
+
+| Filename Pattern | Course Name |
+|-----------------|-------------|
+| `Agent Academy - Special Ops_ YAML Specialist` | Special Ops: YAML Specialist |
+| `Agent Academy - Special Ops_Microsoft Copilot Studio...MCP` | Special Ops: Microsoft Copilot Studio MCP |
+| `Agent Academy - Special Ops_ Microsoft Learn Docs MCP Server` | Special Ops: Microsoft Learn Docs MCP Server |
+| `Agent Academy - Special Ops_⚡ Power Platform CLI MCP Server` | Special Ops: Power Platform CLI MCP Server |
+| `Copilot Studio Agent Academy - Operative` | Operative |
+| `Copilot Studio Agent Academy - Recruit` | Recruit |
+| `Cowork Collective_ Badge Check` | Cowork Collective: Badge Check |
+| `Cowork Collective_ Compliance Packet` | Cowork Collective: Compliance Packet |
+| `Cowork Collective_ Out of Office` | Cowork Collective: Out of Office |
+
+Note: filenames may contain non-breaking spaces (`\xa0`) — normalize these to regular spaces before matching.
+
+---
+
+## Running the Full Pipeline
+
+To generate a complete report in one go:
+
+```bash
+# 1. Extract from Excel
+python3 <skill-path>/scripts/extract_feedback.py "<workspace>/report"
+
+# 2. (Manually fetch GitHub issues via MCP tools and append to _extracted.json → _all_feedback.json)
+
+# 3. Analyze sentiment
+python3 <skill-path>/scripts/analyze_sentiment.py "<workspace>/report"
+
+# 4. Generate charts
+python3 <skill-path>/scripts/generate_charts.py "<workspace>/report"
+
+# 5. Build markdown
+python3 <skill-path>/scripts/build_markdown.py "<workspace>/report"
+
+# 6. Export PDF
+python3 <skill-path>/scripts/export_pdf.py "<workspace>/report" "Agent Academy - Report April 2026"
+```
+
+Step 2 requires the GitHub MCP tools and should be done interactively by the agent between steps 1 and 3.

--- a/.github/skills/agent-academy-report/scripts/analyze_sentiment.py
+++ b/.github/skills/agent-academy-report/scripts/analyze_sentiment.py
@@ -1,0 +1,170 @@
+#!/usr/bin/env python3
+"""Analyze sentiment for extracted feedback records.
+
+Usage: python3 analyze_sentiment.py <workspace-path>
+
+Reads <workspace>/data/_all_feedback.json (or _extracted.json if _all_feedback
+doesn't exist), scores sentiment, detects themes, computes per-course grades.
+Outputs <workspace>/data/_analyzed.json.
+"""
+
+import json
+import os
+import re
+import sys
+from collections import defaultdict
+
+
+POSITIVE_WORDS = [
+    r'\b(great|excellent|amazing|awesome|fantastic|wonderful|love[ds]?|enjoy|enjoyed)\b',
+    r'\b(helpful|useful|informative|well done|good job|thank|thanks|appreciate|impressive)\b',
+    r'\b(learned|learning|eye.?opening|recommend|looking forward|fun|excited|brilliant)\b',
+    r'\b(clear|intuitive|practical|hands.?on|well.?structured|well.?organized)\b',
+    r'\b(good|nice|cool|neat|super|stellar|outstanding|perfect|phenomenal)\b',
+    r'\b(beginner.?friendly|easy to follow|straightforward|engaging|interesting)\b',
+    r'\b(valuable|insightful|comprehensive|thorough|solid|smooth)\b',
+    r'👍|🎉|🙌|❤️|🔥|💯|⭐|✨|😍|😊|🤩|💪',
+]
+
+NEGATIVE_WORDS = [
+    r'\b(error|errors)\b', r'\b(issue|issues)\b', r'\b(problem|problems)\b',
+    r'\b(bug|bugs|buggy)\b', r'\b(broke|broken|crash|crashed)\b',
+    r'\b(fail|failed|failure)\b', r'\bdidn.t work\b', r'\bnot work\b',
+    r'\bcouldn.t\b', r'\bstuck\b', r'\bstruggl\w*\b', r'\bmissing\b',
+    r'\btrouble\b', r'\bdifficult\w*\b', r'\bcumbersome\b', r'\bchallenges?\b',
+    r'\btroubleshoot\w*\b', r'\bconfus\w*\b', r'\bfrustrat\w*\b', r'\bslow\b',
+    r'\bcomplex\b', r'\bunclear\b', r'\bimprove\w*\b', r'\bwish\b',
+    r'\black\w*\b', r'\bdisappoint\w*\b',
+]
+
+THEME_KEYWORDS = {
+    'Hands-on & Practical Learning': [r'hands.?on', r'practical', r'interactive', r'step.?by.?step', r'real.?world', r'exercise'],
+    'Clear Instructions & Documentation': [r'clear', r'well.?document', r'well.?explain', r'easy to follow', r'straightforward', r'step.?by.?step', r'instructions?'],
+    'MCP & Agent Development Skills': [r'mcp', r'copilot studio', r'agent', r'connector', r'power automate', r'topic', r'action'],
+    'Setup & Configuration Challenges': [r'setup', r'install', r'config', r'environment', r'prerequisite', r'authentication', r'credentials?'],
+    'VS Code Integration': [r'vs ?code', r'visual studio code', r'extension', r'editor', r'debug'],
+    'Valuable Learning Experience': [r'learn', r'knowledge', r'understand', r'skill', r'experience', r'educational', r'insight'],
+    'Course Quality & Engagement': [r'well.?design', r'engag', r'interest', r'quality', r'structure', r'organized', r'professional'],
+    'Errors & Technical Issues': [r'error', r'bug', r'crash', r'broke', r'fail', r'fix', r'workaround'],
+    'Improvement Suggestions': [r'improv', r'suggest', r'would be nice', r'could be', r'hope', r'wish', r'add more', r'future'],
+    'Real-World Applicability': [r'real.?world', r'production', r'business', r'enterprise', r'workplace', r'appl'],
+}
+
+
+def score_sentiment(text):
+    if not text:
+        return "neutral"
+    pos = sum(1 for p in POSITIVE_WORDS if re.search(p, text, re.IGNORECASE))
+    neg = sum(1 for p in NEGATIVE_WORDS if re.search(p, text, re.IGNORECASE))
+    if neg > pos:
+        return "negative"
+    elif pos > 0:
+        return "positive"
+    elif neg > 0:
+        return "negative"
+    return "neutral"
+
+
+def detect_themes(text):
+    if not text:
+        return []
+    themes = []
+    for theme, keywords in THEME_KEYWORDS.items():
+        if any(re.search(kw, text, re.IGNORECASE) for kw in keywords):
+            themes.append(theme)
+    return themes
+
+
+def compute_grade(items):
+    if not items:
+        return 0
+    scores = {'positive': 10, 'neutral': 6, 'negative': 2}
+    return round(sum(scores.get(r['sentiment'], 6) for r in items) / len(items), 1)
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python3 analyze_sentiment.py <workspace-path>")
+        sys.exit(1)
+
+    workspace = sys.argv[1]
+    data_dir = os.path.join(workspace, "data")
+
+    # Prefer _all_feedback.json (includes GitHub issues), fall back to _extracted.json
+    input_path = os.path.join(data_dir, "_all_feedback.json")
+    if not os.path.exists(input_path):
+        input_path = os.path.join(data_dir, "_extracted.json")
+    if not os.path.exists(input_path):
+        print(f"No input file found. Run extract_feedback.py first.")
+        sys.exit(1)
+
+    with open(input_path) as f:
+        records = json.load(f)
+
+    print(f"Loaded {len(records)} records from {os.path.basename(input_path)}")
+
+    # Score sentiment and detect themes
+    for r in records:
+        if r.get('text') and r['type'] == 'feedback':
+            r['sentiment'] = score_sentiment(r['text'])
+            r['themes'] = detect_themes(r['text'])
+        elif r['sentiment'] is None:
+            r['sentiment'] = None  # completions without feedback
+            r['themes'] = []
+
+    feedback = [r for r in records if r['type'] == 'feedback']
+    pos = sum(1 for r in feedback if r['sentiment'] == 'positive')
+    neu = sum(1 for r in feedback if r['sentiment'] == 'neutral')
+    neg = sum(1 for r in feedback if r['sentiment'] == 'negative')
+
+    print(f"\nOverall sentiment ({len(feedback)} feedback items):")
+    print(f"  Positive: {pos} ({pos/len(feedback)*100:.0f}%)")
+    print(f"  Neutral:  {neu} ({neu/len(feedback)*100:.0f}%)")
+    print(f"  Negative: {neg} ({neg/len(feedback)*100:.0f}%)")
+    print(f"  Grade: {compute_grade(feedback)}/10")
+
+    # Per-course stats
+    courses = sorted(set(r['course'] for r in feedback))
+    course_stats = {}
+    for course in courses:
+        items = [r for r in feedback if r['course'] == course]
+        grade = compute_grade(items)
+        stats = {
+            'total': len(items),
+            'positive': sum(1 for r in items if r['sentiment'] == 'positive'),
+            'neutral': sum(1 for r in items if r['sentiment'] == 'neutral'),
+            'negative': sum(1 for r in items if r['sentiment'] == 'negative'),
+            'grade': grade,
+        }
+        # Theme counts
+        theme_counts = defaultdict(int)
+        for r in items:
+            for t in r.get('themes', []):
+                theme_counts[t] += 1
+        stats['themes'] = dict(sorted(theme_counts.items(), key=lambda x: -x[1]))
+        course_stats[course] = stats
+        print(f"  {course}: {stats['total']} items, grade {grade}/10")
+
+    # Save analyzed data
+    output = {
+        'records': records,
+        'summary': {
+            'total_records': len(records),
+            'total_feedback': len(feedback),
+            'positive': pos,
+            'neutral': neu,
+            'negative': neg,
+            'overall_grade': compute_grade(feedback),
+        },
+        'course_stats': course_stats,
+    }
+
+    output_path = os.path.join(data_dir, "_analyzed.json")
+    with open(output_path, 'w') as f:
+        json.dump(output, f, indent=2, default=str)
+
+    print(f"\nSaved to {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/skills/agent-academy-report/scripts/build_markdown.py
+++ b/.github/skills/agent-academy-report/scripts/build_markdown.py
@@ -1,0 +1,423 @@
+#!/usr/bin/env python3
+"""Build markdown report files from analyzed feedback data.
+
+Usage: python3 build_markdown.py <workspace-path>
+
+Reads <workspace>/data/_analyzed.json and generates three markdown files
+in <workspace>/markdown/:
+  - management-summary.md
+  - feedback-analysis.md
+  - feedback.md (positive-only curated)
+"""
+
+import json
+import os
+import re
+import sys
+from collections import defaultdict
+
+COURSE_ORDER = [
+    "Recruit", "Operative",
+    "Special Ops: YAML Specialist", "Special Ops: Microsoft Copilot Studio MCP",
+    "Special Ops: Microsoft Learn Docs MCP Server", "Special Ops: Power Platform CLI MCP Server",
+    "Cowork Collective: Badge Check", "Cowork Collective: Compliance Packet", "Cowork Collective: Out of Office",
+]
+
+ERROR_PATTERNS = [
+    r'\berror\b', r'\bfail\b', r'\bcrash\b', r'\bbroke\b', r'\bbug\b',
+    r'\bstuck\b', r'\bdidn.t work\b', r'\bnot work\b',
+]
+
+
+def build_management_summary(data, workspace):
+    """Generate management-summary.md."""
+    summary = data['summary']
+    course_stats = data['course_stats']
+    records = data['records']
+
+    total_completions = len(records)
+    total_feedback = summary['total_feedback']
+    overall_grade = summary['overall_grade']
+    pos_pct = round(summary['positive'] / total_feedback * 100)
+    neu_pct = round(summary['neutral'] / total_feedback * 100)
+    neg_pct = round(summary['negative'] / total_feedback * 100)
+
+    highest_course = max(course_stats, key=lambda c: course_stats[c]['grade'])
+    lowest_course = min(course_stats, key=lambda c: course_stats[c]['grade'])
+    num_courses = len(course_stats)
+
+    dates = sorted(r['date'] for r in records if r.get('date'))
+    date_start = dates[0] if dates else "N/A"
+    date_end = dates[-1] if dates else "N/A"
+
+    recruit_count = sum(1 for r in records if r['course'] == 'Recruit')
+    operative_count = sum(1 for r in records if r['course'] == 'Operative')
+
+    md = f"""# Management Summary
+
+**Report Period:** {date_start} to {date_end}
+
+---
+
+## Key Metrics at a Glance
+
+| Metric | Value |
+|--------|-------|
+| Total Course Completions | **{total_completions:,}** |
+| Feedback Responses Collected | **{total_feedback}** |
+| Courses Tracked | **{num_courses}** |
+| Overall Satisfaction Grade | **{overall_grade}/10** |
+| Positive Sentiment | **{pos_pct}%** |
+| Neutral Sentiment | **{neu_pct}%** |
+| Negative Sentiment | **{neg_pct}%** |
+
+### Highlights
+
+- **{recruit_count:,}** Recruit completions — the largest program by volume
+- **{operative_count}** Operative completions — strong advanced engagement
+- **Highest rated:** {highest_course} ({course_stats[highest_course]['grade']}/10)
+- **Lowest rated:** {lowest_course} ({course_stats[lowest_course]['grade']}/10) — still above average
+
+---
+
+## Overall Sentiment
+
+![Overall Feedback Sentiment](../charts/sentiment_pie.png)
+
+Across all {total_feedback} feedback responses, **{pos_pct}%** of participants expressed positive sentiment. Only **{neg_pct}%** reported negative experiences, primarily around setup challenges and tooling errors.
+
+---
+
+## Completions Over Time
+
+![Completions Over Time](../charts/completions_over_time.png)
+
+Weekly completion volumes show strong sustained engagement. The Recruit program launched first and continues to drive the majority of completions. Operative and Special Ops courses launched later and show healthy growth patterns.
+
+---
+
+## Cumulative Growth
+
+![Cumulative Completions](../charts/cumulative_completions.png)
+
+Cumulative completion curves demonstrate consistent growth across all program tiers. The Recruit program shows the steepest growth curve with **{recruit_count:,}** total completions.
+
+---
+
+## Feedback Volume by Month
+
+![Monthly Feedback Volume](../charts/monthly_feedback.png)
+
+Feedback collection ramps up as new courses are introduced, with sentiment remaining overwhelmingly positive across all months.
+
+---
+
+## Sentiment by Course
+
+![Sentiment Distribution](../charts/sentiment_by_course.png)
+
+All courses maintain majority positive sentiment. The Cowork Collective courses consistently show the highest satisfaction rates. Special Ops courses, being more technical, show slightly higher neutral/negative ratios due to tooling complexity.
+
+---
+
+## Course Grades
+
+![Course Grades](../charts/grades_by_course.png)
+
+All courses score between **{course_stats[lowest_course]['grade']}/10** and **{course_stats[highest_course]['grade']}/10**. The grade is a weighted average where positive=10, neutral=6, and negative=2.
+
+---
+
+"""
+
+    # --- Per-course spotlight section ---
+    feedback = [r for r in records if r['type'] == 'feedback']
+
+    md += "## Course Spotlights\n\n"
+
+    for course in COURSE_ORDER:
+        if course not in course_stats:
+            continue
+        s = course_stats[course]
+        t = s['total']
+        pos_pct_c = round(s['positive'] / t * 100)
+        neg_pct_c = round(s['negative'] / t * 100)
+        grade = s['grade']
+
+        items = [r for r in feedback if r['course'] == course]
+        pos_items = [r for r in items if r.get('sentiment') == 'positive']
+        neg_items = [r for r in items if r.get('sentiment') == 'negative']
+
+        # Top themes
+        themes = s.get('themes', {})
+        top_themes = sorted(themes.items(), key=lambda x: -x[1])[:3]
+
+        # Grade explanation
+        if grade >= 9.0:
+            grade_note = "Exceptional satisfaction — one of the top-rated courses."
+        elif grade >= 8.5:
+            grade_note = "Strong satisfaction with consistently positive feedback."
+        elif grade >= 8.0:
+            grade_note = "Good satisfaction, though some participants encountered challenges."
+        else:
+            grade_note = "Solid course, but a higher neutral/negative ratio pulls the grade down."
+
+        # Pick quotes proportional to grade (grade 9.1 → 91% positive → ~5 pos out of 5)
+        total_quotes = 5
+        num_pos_q = min(total_quotes, max(1, int(total_quotes * grade / 10 + 0.5)))
+        num_neg_q = total_quotes - num_pos_q
+        # Ensure we don't exceed available quotes
+        num_pos_q = min(num_pos_q, len(pos_items))
+        num_neg_q = min(num_neg_q, len(neg_items))
+        # Fill remaining slots from the other side
+        if num_pos_q + num_neg_q < total_quotes:
+            extra = total_quotes - num_pos_q - num_neg_q
+            if len(pos_items) > num_pos_q:
+                add = min(extra, len(pos_items) - num_pos_q)
+                num_pos_q += add
+                extra -= add
+            if extra and len(neg_items) > num_neg_q:
+                num_neg_q += min(extra, len(neg_items) - num_neg_q)
+        best_pos = sorted(pos_items, key=lambda r: abs(len(r.get('text', '')) - 250))[:num_pos_q]
+        best_neg = sorted(neg_items, key=lambda r: abs(len(r.get('text', '')) - 200))[:num_neg_q]
+
+        md += f"### {course}\n\n"
+        md += f"**{t} responses** · Grade: **{grade}/10** · "
+        md += f"👍 {pos_pct_c}% positive · 👎 {neg_pct_c}% negative\n\n"
+        md += f"{grade_note}\n\n"
+
+        if top_themes:
+            md += "**Top themes:** "
+            md += ", ".join(f"{th} ({cnt})" for th, cnt in top_themes)
+            md += "\n\n"
+
+        # Highlight
+        if pos_pct_c >= 85:
+            md += f"**Standout:** {pos_pct_c}% of respondents were positive — learners particularly valued "
+            if top_themes:
+                md += f"the {top_themes[0][0].lower()}.\n\n"
+            else:
+                md += "the course content.\n\n"
+        elif neg_pct_c >= 15:
+            md += f"**Watch area:** {neg_pct_c}% reported negative experiences, "
+            neg_themes = [(th, cnt) for th, cnt in themes.items()
+                         if any(r['sentiment'] == 'negative' and th in r.get('themes', []) for r in neg_items)]
+            if neg_themes:
+                top_neg_theme = sorted(neg_themes, key=lambda x: -x[1])[0][0]
+                md += f"primarily around {top_neg_theme.lower()}.\n\n"
+            else:
+                md += "primarily around technical challenges.\n\n"
+
+        def clean_quote(text, max_len=200):
+            """Clean up a quote for display."""
+            text = text.replace('\n', ' ').replace('\r', ' ')
+            text = re.sub(r'\*\*[^*]+\*\*\s*', '', text)  # Remove bold headers
+            text = re.sub(r'#+\s+[^\n]+\s*', '', text)  # Remove markdown headers
+            text = re.sub(r'- \[.\][^-]*', '', text)  # Remove checkbox lines
+            text = re.sub(r'^\s*-\s+', '', text)  # Remove leading list dash
+            text = re.sub(r'\s+-\s+', '. ', text)  # Convert list dashes to periods
+            text = re.sub(r'&#39;', "'", text)  # Fix HTML entities
+            text = re.sub(r'&amp;', '&', text)
+            text = re.sub(r'\s+', ' ', text).strip()
+            if len(text) > max_len:
+                # Cut at sentence boundary
+                cut = text[:max_len].rfind('.')
+                if cut > 100:
+                    text = text[:cut + 1]
+                else:
+                    text = text[:max_len].rsplit(' ', 1)[0] + '...'
+            return text
+
+        for q in best_pos:
+            quote = clean_quote(q.get('text', ''))
+            name = q.get('name', 'Anonymous')
+            md += f"> 👍 *\"{quote}\"* — {name}\n\n"
+
+        for q in best_neg:
+            quote = clean_quote(q.get('text', ''), 180)
+            name = q.get('name', 'Anonymous')
+            md += f"> 👎 *\"{quote}\"* — {name}\n\n"
+
+        md += "---\n\n"
+
+    md += """## Recommendations
+
+1. **Address Setup Challenges** — The most common negative theme across technical courses is setup difficulty. Consider providing pre-configured environments or improved setup documentation.
+2. **Expand Cowork Collective** — These courses have the highest satisfaction; consider adding more missions in this format.
+3. **Scale Special Ops** — Technical courses show strong engagement; the slightly lower grades present an opportunity for targeted improvements.
+4. **Continue Monitoring** — The feedback pipeline provides ongoing insights; consider monthly reviews to track sentiment trends.
+
+---
+
+*Report generated from {total_completions:,} course completions and {total_feedback} feedback responses across the Agent Academy program.*
+"""
+
+    md_dir = os.path.join(workspace, "markdown")
+    os.makedirs(md_dir, exist_ok=True)
+    path = os.path.join(md_dir, "management-summary.md")
+    with open(path, 'w') as f:
+        f.write(md)
+    print(f"  Written: {path}")
+
+
+def build_feedback_analysis(data, workspace):
+    """Generate feedback-analysis.md with full detailed analysis."""
+    summary = data['summary']
+    course_stats = data['course_stats']
+    records = data['records']
+    feedback = [r for r in records if r['type'] == 'feedback']
+
+    total = summary['total_feedback']
+    pos = summary['positive']
+    neu = summary['neutral']
+    neg = summary['negative']
+
+    lines = []
+    lines.append(f"# Agent Academy Feedback Analysis\n")
+    lines.append(f"**{total} feedback responses** across {len(course_stats)} courses\n")
+    lines.append(f"| Sentiment | Count | Percentage |")
+    lines.append(f"|-----------|------:|-----------:|")
+    lines.append(f"| 👍 Positive | {pos} | {pos*100//total}% |")
+    lines.append(f"| ➖ Neutral | {neu} | {neu*100//total}% |")
+    lines.append(f"| 👎 Negative | {neg} | {neg*100//total}% |")
+    lines.append(f"| **Total** | **{total}** | **100%** |")
+    lines.append(f"\n**Overall Grade: {summary['overall_grade']}/10**\n")
+
+    # Course overview table
+    lines.append("## Course Overview\n")
+    lines.append("| Course | Responses | 👍 Positive | ➖ Neutral | 👎 Negative | Grade |")
+    lines.append("|--------|----------:|------------:|-----------:|------------:|------:|")
+    for course in COURSE_ORDER:
+        if course not in course_stats:
+            continue
+        s = course_stats[course]
+        t = s['total']
+        lines.append(
+            f"| {course} | {t} | {s['positive']} ({s['positive']*100//t}%) "
+            f"| {s['neutral']} ({s['neutral']*100//t}%) "
+            f"| {s['negative']} ({s['negative']*100//t}%) "
+            f"| **{s['grade']}/10** |"
+        )
+
+    lines.append("\n---\n")
+
+    # Per-course sections
+    for course in COURSE_ORDER:
+        if course not in course_stats:
+            continue
+        s = course_stats[course]
+        t = s['total']
+        items = [r for r in feedback if r['course'] == course]
+
+        lines.append(f"## {course}\n")
+        lines.append(
+            f"**{t} responses** — 👍 {s['positive']} ({s['positive']*100//t}%) "
+            f"· ➖ {s['neutral']} ({s['neutral']*100//t}%) "
+            f"· 👎 {s['negative']} ({s['negative']*100//t}%) "
+            f"· **Grade: {s['grade']}/10**\n"
+        )
+
+        # Themes
+        if s.get('themes'):
+            lines.append("### Common Themes\n")
+            pos_themes = [(th, cnt) for th, cnt in s['themes'].items()
+                          if any(r['sentiment'] == 'positive' and th in r.get('themes', []) for r in items)]
+            neg_themes = [(th, cnt) for th, cnt in s['themes'].items()
+                          if any(r['sentiment'] == 'negative' and th in r.get('themes', []) for r in items)]
+
+            if pos_themes:
+                lines.append("**👍 Positive themes:**\n")
+                for th, cnt in sorted(s['themes'].items(), key=lambda x: -x[1]):
+                    lines.append(f"- {th} ({cnt} mentions)")
+            if neg_themes:
+                lines.append("\n**👎 Negative themes:**\n")
+                for th, _ in neg_themes:
+                    neg_count = sum(1 for r in items if r['sentiment'] == 'negative' and th in r.get('themes', []))
+                    lines.append(f"- {th} ({neg_count} mentions)")
+
+        # Feedback items sorted: positive → neutral → negative
+        lines.append("\n### Feedback\n")
+        sort_order = {'positive': 0, 'neutral': 1, 'negative': 2}
+        sorted_items = sorted(items, key=lambda r: sort_order.get(r.get('sentiment', 'neutral'), 1))
+
+        for i, r in enumerate(sorted_items):
+            text = r.get('text', '')
+            if not text:
+                continue
+
+            emoji = {'positive': '👍', 'neutral': '➖', 'negative': '👎'}.get(r.get('sentiment', 'neutral'), '➖')
+            name = r.get('name', 'Anonymous') or 'Anonymous'
+
+            # Format as blockquote (prefix every line with >)
+            quoted = '\n'.join(f'> {line}' for line in f'{emoji} "{text}" — {name}'.split('\n'))
+            lines.append(quoted)
+
+            if i < len(sorted_items) - 1:
+                lines.append("\n---\n")
+
+        lines.append("\n---\n")
+
+    md_dir = os.path.join(workspace, "markdown")
+    os.makedirs(md_dir, exist_ok=True)
+    path = os.path.join(md_dir, "feedback-analysis.md")
+    with open(path, 'w') as f:
+        f.write('\n'.join(lines))
+    print(f"  Written: {path}")
+
+
+def build_positive_feedback(data, workspace):
+    """Generate feedback.md with curated positive-only feedback."""
+    records = data['records']
+    feedback = [r for r in records if r['type'] == 'feedback' and r.get('sentiment') == 'positive']
+
+    # Exclude entries mentioning errors
+    filtered = []
+    for r in feedback:
+        text = r.get('text', '')
+        if any(re.search(p, text, re.IGNORECASE) for p in ERROR_PATTERNS):
+            continue
+        filtered.append(r)
+
+    lines = ["# Agent Academy Feedback\n"]
+    for i, r in enumerate(filtered):
+        text = r.get('text', '')
+        name = r.get('name', 'Anonymous') or 'Anonymous'
+        course = r.get('course', '')
+
+        quoted = '\n'.join(f'> {line}' for line in f'👍 "{text}" — {name} ({course})'.split('\n'))
+        lines.append(quoted)
+
+        if i < len(filtered) - 1:
+            lines.append("\n---\n")
+
+    md_dir = os.path.join(workspace, "markdown")
+    os.makedirs(md_dir, exist_ok=True)
+    path = os.path.join(md_dir, "feedback.md")
+    with open(path, 'w') as f:
+        f.write('\n'.join(lines))
+    print(f"  Written: {path} ({len(filtered)} items)")
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python3 build_markdown.py <workspace-path>")
+        sys.exit(1)
+
+    workspace = sys.argv[1]
+    data_path = os.path.join(workspace, "data", "_analyzed.json")
+    if not os.path.exists(data_path):
+        print("No analyzed data found. Run analyze_sentiment.py first.")
+        sys.exit(1)
+
+    with open(data_path) as f:
+        data = json.load(f)
+
+    print("Building markdown files...")
+    build_management_summary(data, workspace)
+    build_feedback_analysis(data, workspace)
+    build_positive_feedback(data, workspace)
+    print("Done!")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/skills/agent-academy-report/scripts/export_pdf.py
+++ b/.github/skills/agent-academy-report/scripts/export_pdf.py
@@ -1,0 +1,494 @@
+#!/usr/bin/env python3
+"""Export a single combined PDF report with cover page, management summary, and analysis.
+
+Usage: python3 export_pdf.py <workspace-path> "<Report Title>"
+
+Downloads badge images if needed, builds a combined HTML with cover page,
+converts markdown sections to HTML with embedded charts, and exports to PDF
+using headless Microsoft Edge (or Chrome).
+"""
+
+import base64
+import json
+import os
+import re
+import subprocess
+import sys
+import urllib.request
+
+
+BADGE_FILES = {
+    'logo': 'logo.png',
+    'recruit': 'mcs-agent-academy-recruit-badge.png',
+    'operative': 'mcs-agent-academy-operative-badge.png',
+    'commander': 'mcs-agent-academy-commander-badge.png',
+    'yaml': 'YAML_Specialist_Badge.png',
+    'learn_mcp': 'Academy_LearnMCP_Badge.png',
+    'cli': 'CommandLine_Badge.png',
+    'badge_bandit': 'BadgeBandit-badge.png',
+    'audit_ace': 'AuditAce-badge.png',
+    'vacay': 'Vacay-badge.png',
+    'mcp_joker': 'MCP_Joker_Badge.png',
+}
+
+BADGE_BASE_URL = "https://raw.githubusercontent.com/microsoft/agent-academy/main/docs/public/images"
+
+BROWSER_PATHS = [
+    "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge",
+    "/usr/bin/microsoft-edge",
+    "/Applications/Google Chrome.app/Contents/MacOS/Google Chrome",
+    "/usr/bin/google-chrome",
+]
+
+
+def find_browser():
+    for path in BROWSER_PATHS:
+        if os.path.exists(path):
+            return path
+    return None
+
+
+def img_to_b64(path):
+    with open(path, 'rb') as f:
+        return base64.b64encode(f.read()).decode()
+
+
+def download_badges(badges_dir):
+    """Download badge images from GitHub if not already present."""
+    os.makedirs(badges_dir, exist_ok=True)
+    for key, fname in BADGE_FILES.items():
+        path = os.path.join(badges_dir, fname)
+        if not os.path.exists(path):
+            url = f"{BADGE_BASE_URL}/{fname}"
+            print(f"  Downloading {fname}...")
+            urllib.request.urlretrieve(url, path)
+
+
+def embed_md_images(html, base_dir):
+    """Replace markdown image refs with base64-embedded images."""
+    def replacer(match):
+        alt = match.group(1)
+        src = match.group(2)
+        full = os.path.join(base_dir, src) if not os.path.isabs(src) else src
+        if os.path.exists(full):
+            b64 = img_to_b64(full)
+            return f'<img src="data:image/png;base64,{b64}" alt="{alt}" style="max-width:100%; margin:15px 0;">'
+        return match.group(0)
+    return re.sub(r'!\[([^\]]*)\]\(([^)]+)\)', replacer, html)
+
+
+def md_to_html(md_text, base_dir):
+    """Convert markdown to HTML."""
+    html = md_text
+
+    # Embed images first
+    html = embed_md_images(html, base_dir)
+
+    # Headings
+    html = re.sub(r'^#### (.+)$', r'<h4>\1</h4>', html, flags=re.MULTILINE)
+    html = re.sub(r'^### (.+)$', r'<h3>\1</h3>', html, flags=re.MULTILINE)
+    html = re.sub(r'^## (.+)$', r'<h2>\1</h2>', html, flags=re.MULTILINE)
+    html = re.sub(r'^# (.+)$', r'<h1>\1</h1>', html, flags=re.MULTILINE)
+
+    # Bold
+    html = re.sub(r'\*\*(.+?)\*\*', r'<strong>\1</strong>', html)
+
+    # Italic
+    html = re.sub(r'(?<!\*)\*(?!\*)(.+?)(?<!\*)\*(?!\*)', r'<em>\1</em>', html)
+
+    # Tables
+    lines = html.split('\n')
+    new_lines = []
+    in_table = False
+    for line in lines:
+        stripped = line.strip()
+        if '|' in stripped and stripped.startswith('|') and stripped.endswith('|'):
+            cells = [c.strip() for c in stripped.split('|')[1:-1]]
+            if all(re.match(r'^[-:]+$', c) for c in cells):
+                continue
+            if not in_table:
+                new_lines.append('<table>')
+                tag = 'th'
+                in_table = True
+            else:
+                tag = 'td'
+            row_cells = ''.join(f'<{tag}>{c}</{tag}>' for c in cells)
+            new_lines.append(f'<tr>{row_cells}</tr>')
+        else:
+            if in_table:
+                new_lines.append('</table>')
+                in_table = False
+            new_lines.append(line)
+    if in_table:
+        new_lines.append('</table>')
+    html = '\n'.join(new_lines)
+
+    # Horizontal rules
+    html = re.sub(r'\n---\n', '\n<hr>\n', html)
+
+    # Blockquotes
+    lines = html.split('\n')
+    new_lines = []
+    in_bq = False
+    bq_buf = []
+    for line in lines:
+        if line.startswith('> '):
+            bq_buf.append(line[2:])
+            in_bq = True
+        elif line == '>' and in_bq:
+            bq_buf.append('')
+        else:
+            if in_bq:
+                new_lines.append('<blockquote>' + '<br>'.join(bq_buf) + '</blockquote>')
+                bq_buf = []
+                in_bq = False
+            new_lines.append(line)
+    if in_bq:
+        new_lines.append('<blockquote>' + '<br>'.join(bq_buf) + '</blockquote>')
+    html = '\n'.join(new_lines)
+
+    # List items
+    html = re.sub(r'^- (.+)$', r'<li>\1</li>', html, flags=re.MULTILINE)
+    html = re.sub(r'^(\d+)\. (.+)$', r'<li>\2</li>', html, flags=re.MULTILINE)
+
+    # URLs
+    html = re.sub(r'<(https?://[^>]+)>', r'<a href="\1">\1</a>', html)
+
+    # Paragraphs
+    html = re.sub(r'\n\n(?!<)', '\n<p>\n', html)
+
+    # Wrap chart images + surrounding text in keep-together blocks
+    # Pattern: a paragraph/text followed by an <img>, optionally followed by italic/emphasis text
+    html = re.sub(
+        r'(<p>\s*(?:<strong>[^<]*</strong>[^<]*)?\s*<img [^>]+>\s*(?:<p>\s*)?(?:<em>[^<]*</em>)?)',
+        r'<div class="chart-block">\1</div>',
+        html
+    )
+
+    # Wrap each h3 + its content until next h3/h2/hr as a course-spotlight
+    def wrap_spotlights(html_text):
+        parts = re.split(r'(?=<h3>)', html_text)
+        result = []
+        for part in parts:
+            if part.startswith('<h3>'):
+                result.append(f'<div class="course-spotlight">{part}</div>')
+            else:
+                result.append(part)
+        return ''.join(result)
+
+    html = wrap_spotlights(html)
+
+    return html
+
+
+def build_html(workspace, title):
+    """Build the combined HTML report."""
+    badges_dir = os.path.join(workspace, "badges")
+    md_dir = os.path.join(workspace, "markdown")
+
+    # Load badge images
+    badges_b64 = {}
+    for key, fname in BADGE_FILES.items():
+        path = os.path.join(badges_dir, fname)
+        if os.path.exists(path):
+            badges_b64[key] = img_to_b64(path)
+
+    # Read markdown files
+    with open(os.path.join(md_dir, 'management-summary.md')) as f:
+        mgmt_md = f.read()
+    with open(os.path.join(md_dir, 'feedback-analysis.md')) as f:
+        analysis_md = f.read()
+
+    # Strip H1 titles (we use our own)
+    mgmt_md = re.sub(r'^# .+\n', '', mgmt_md).strip()
+    analysis_md = re.sub(r'^# .+\n', '', analysis_md).strip()
+
+    # Convert to HTML (resolve image paths relative to markdown/)
+    mgmt_html = md_to_html(mgmt_md, md_dir)
+    analysis_html = md_to_html(analysis_md, md_dir)
+
+    # Badge row
+    badge_row_keys = ['recruit', 'operative', 'commander', 'yaml', 'learn_mcp', 'cli', 'badge_bandit', 'audit_ace', 'vacay', 'mcp_joker']
+    badge_imgs = '\n'.join(
+        f'<img src="data:image/png;base64,{badges_b64[k]}" alt="{k}" class="badge-img">'
+        for k in badge_row_keys if k in badges_b64
+    )
+    logo_img = f'<img src="data:image/png;base64,{badges_b64["logo"]}" alt="Agent Academy Logo" class="cover-logo">' if 'logo' in badges_b64 else ''
+
+    # Parse title for display
+    title_parts = title.split(' - ', 1)
+    main_title = title_parts[0]
+    subtitle = title_parts[1] if len(title_parts) > 1 else ''
+
+    return f"""<!DOCTYPE html>
+<html>
+<head>
+<meta charset="utf-8">
+<style>
+@import url('https://fonts.googleapis.com/css2?family=Outfit:wght@300;400;600;800;900&family=JetBrains+Mono:wght@400;600&display=swap');
+
+@page {{ margin: 0; size: A4; }}
+:root {{
+    --navy-deep: #0a0e1a;
+    --navy: #111827;
+    --navy-mid: #1a2332;
+    --teal: #2dd4bf;
+    --teal-dim: rgba(45,212,191,0.15);
+    --gold: #fbbf24;
+    --gold-dim: rgba(251,191,36,0.12);
+    --slate: #94a3b8;
+    --brand-blue: #0078d4;
+}}
+body {{
+    font-family: 'Outfit', -apple-system, 'Segoe UI', Helvetica, sans-serif;
+    color: #334155; line-height: 1.65; margin: 0; padding: 0;
+}}
+
+/* ═══ COVER PAGE ═══ */
+.cover-page {{
+    width: 100%; height: 100vh; position: relative; overflow: hidden;
+    background: var(--navy-deep);
+    display: flex; flex-direction: column;
+    justify-content: center; align-items: center;
+    page-break-after: always; box-sizing: border-box;
+    padding: 50px 40px;
+}}
+/* Radial glow behind mascot */
+.cover-page::before {{
+    content: ''; position: absolute;
+    width: 600px; height: 600px;
+    top: 50%; left: 50%; transform: translate(-50%, -55%);
+    background: radial-gradient(circle, rgba(45,212,191,0.08) 0%, rgba(45,212,191,0.03) 40%, transparent 70%);
+    border-radius: 50%;
+}}
+/* Grid overlay — faded via transparent gradient stop (mask-image breaks in headless PDF) */
+.cover-page::after {{
+    content: ''; position: absolute; inset: 0;
+    background-image:
+        linear-gradient(rgba(45,212,191,0.03) 1px, transparent 1px),
+        linear-gradient(90deg, rgba(45,212,191,0.03) 1px, transparent 1px);
+    background-size: 48px 48px;
+    opacity: 0.5;
+}}
+
+/* Top accent bar */
+.cover-accent-top {{
+    position: absolute; top: 0; left: 0; right: 0; height: 4px;
+    background: linear-gradient(90deg, var(--teal), var(--gold), var(--teal));
+}}
+
+/* Classification tag */
+.cover-classification {{
+    position: absolute; top: 28px; right: 40px;
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 10px; letter-spacing: 3px; text-transform: uppercase;
+    color: var(--teal); opacity: 0.5;
+    border: 1px solid rgba(45,212,191,0.2); padding: 4px 14px;
+    border-radius: 2px;
+}}
+
+/* Logo */
+.cover-logo {{
+    width: 140px; height: auto;
+    filter: drop-shadow(0 0 30px rgba(45,212,191,0.2)) drop-shadow(0 6px 16px rgba(0,0,0,0.4));
+    position: relative; z-index: 2;
+    margin-bottom: 16px;
+}}
+
+/* Title group */
+.cover-titles {{
+    position: relative; z-index: 2; text-align: center;
+    margin-bottom: 12px;
+}}
+.cover-pretitle {{
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 11px; letter-spacing: 5px; text-transform: uppercase;
+    color: var(--teal); margin-bottom: 12px; opacity: 0.8;
+}}
+.cover-title {{
+    font-size: 46px; font-weight: 900; margin: 0;
+    color: var(--teal);
+    letter-spacing: -1.5px; line-height: 1.05;
+    text-shadow: 0 0 40px rgba(45,212,191,0.3), 0 2px 12px rgba(0,0,0,0.4);
+}}
+.cover-divider {{
+    width: 60px; height: 2px; margin: 14px auto 14px;
+    background: var(--gold);
+}}
+.cover-subtitle {{
+    font-size: 19px; font-weight: 300; color: var(--slate);
+    margin: 0; letter-spacing: 0.5px;
+}}
+
+/* Badge showcase */
+.badge-shelf {{
+    position: relative; z-index: 2;
+    display: flex; flex-wrap: wrap; justify-content: center;
+    gap: 8px; max-width: 420px;
+    margin-top: 28px; padding: 18px 20px 14px;
+    background: rgba(255,255,255,0.03);
+    border: 1px solid rgba(45,212,191,0.1);
+    border-radius: 14px;
+}}
+.badge-shelf-label {{
+    position: absolute; top: -9px; left: 50%; transform: translateX(-50%);
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 9px; letter-spacing: 3px; text-transform: uppercase;
+    color: var(--gold); background: var(--navy-deep);
+    padding: 2px 16px; white-space: nowrap;
+}}
+.badge-img {{
+    width: 68px; height: 68px; object-fit: contain;
+    filter: drop-shadow(0 2px 6px rgba(0,0,0,0.4));
+    border-radius: 8px;
+}}
+
+/* Footer */
+.cover-footer {{
+    position: absolute; bottom: 32px; left: 0; right: 0;
+    text-align: center; z-index: 2;
+}}
+.cover-footer-text {{
+    font-family: 'JetBrains Mono', monospace;
+    font-size: 10px; letter-spacing: 1.5px;
+    color: var(--slate); opacity: 0.4;
+}}
+.cover-footer-line {{
+    width: 140px; height: 1px; margin: 8px auto 0;
+    background: linear-gradient(90deg, transparent, rgba(45,212,191,0.2), transparent);
+}}
+
+/* ═══ CONTENT PAGES ═══ */
+.content {{ max-width: 850px; margin: 0 auto; padding: 40px 50px; }}
+h1 {{
+    font-family: 'Outfit', sans-serif; font-weight: 800;
+    color: var(--navy); font-size: 28px; margin-top: 10px;
+    padding-bottom: 10px;
+    border-bottom: 3px solid var(--brand-blue);
+}}
+h2 {{
+    font-family: 'Outfit', sans-serif; font-weight: 700;
+    color: var(--brand-blue); margin-top: 35px; font-size: 22px;
+    border-bottom: 1px solid #e2e8f0; padding-bottom: 6px;
+}}
+h3 {{ color: #1e293b; font-size: 17px; margin-top: 25px; font-weight: 600; }}
+h4 {{ color: #475569; font-size: 15px; font-weight: 600; }}
+table {{ border-collapse: collapse; margin: 15px 0; width: 100%; font-size: 13px; }}
+th {{ background: var(--navy); color: white; font-weight: 600; padding: 8px 12px; text-align: left; border: 1px solid #1e293b; }}
+td {{ border: 1px solid #e2e8f0; padding: 7px 12px; text-align: left; }}
+tr:nth-child(even) td {{ background: #f8fafc; }}
+img {{ display: block; margin: 20px auto; max-width: 100%; border-radius: 8px; box-shadow: 0 1px 8px rgba(0,0,0,0.06); }}
+blockquote {{
+    border-left: 4px solid var(--brand-blue); margin: 12px 0; padding: 8px 16px;
+    background: #f8fafc; color: #475569; font-size: 13px; line-height: 1.55;
+    border-radius: 0 6px 6px 0;
+}}
+hr {{ border: none; border-top: 1px solid #e2e8f0; margin: 20px 0; }}
+li {{ margin: 4px 0; margin-left: 20px; font-size: 14px; }}
+em {{ color: #64748b; }}
+a {{ color: var(--brand-blue); text-decoration: none; }}
+.section-divider {{ page-break-before: always; border-top: 4px solid var(--brand-blue); margin-top: 40px; padding-top: 20px; }}
+/* Keep-together blocks */
+.keep-together {{ page-break-inside: avoid; break-inside: avoid; }}
+.chart-block {{ page-break-inside: avoid; break-inside: avoid; margin: 10px 0; }}
+.course-spotlight {{ page-break-inside: avoid; break-inside: avoid; margin-bottom: 10px; }}
+@media print {{
+    .cover-page {{ height: 100vh; }}
+    .content {{ padding: 30px 40px; }}
+    img {{ max-width: 100% !important; page-break-inside: avoid; break-inside: avoid; }}
+    h2, h3, h4 {{ page-break-after: avoid; break-after: avoid; }}
+    blockquote {{ page-break-inside: avoid; break-inside: avoid; }}
+    table {{ page-break-inside: avoid; break-inside: avoid; }}
+    .keep-together {{ page-break-inside: avoid; break-inside: avoid; }}
+    .chart-block {{ page-break-inside: avoid; break-inside: avoid; }}
+    .course-spotlight {{ page-break-inside: avoid; break-inside: avoid; }}
+}}
+</style>
+</head>
+<body>
+<div class="cover-page">
+    <div class="cover-accent-top"></div>
+    <div class="cover-classification">Mission Report</div>
+    {logo_img}
+    <div class="cover-titles">
+        <div class="cover-pretitle">Microsoft Copilot Studio</div>
+        <div class="cover-title">{main_title}</div>
+        <div class="cover-divider"></div>
+        <div class="cover-subtitle">{subtitle}</div>
+    </div>
+    <div class="badge-shelf">
+        <span class="badge-shelf-label">Earned Badges</span>
+        {badge_imgs}
+    </div>
+    <div class="cover-footer">
+        <div class="cover-footer-text">microsoft/agent-academy &bull; Comprehensive Feedback &amp; Completion Analysis</div>
+        <div class="cover-footer-line"></div>
+    </div>
+</div>
+<div class="content">
+    <h1>Management Summary</h1>
+    {mgmt_html}
+</div>
+<div class="content section-divider">
+    <h1>Detailed Feedback Analysis</h1>
+    {analysis_html}
+</div>
+</body>
+</html>"""
+
+
+def main():
+    if len(sys.argv) < 3:
+        print('Usage: python3 export_pdf.py <workspace-path> "<Report Title>"')
+        sys.exit(1)
+
+    workspace = sys.argv[1]
+    title = sys.argv[2]
+
+    browser = find_browser()
+    if not browser:
+        print("ERROR: No supported browser found (Edge or Chrome).")
+        sys.exit(1)
+    print(f"Using browser: {browser}")
+
+    badges_dir = os.path.join(workspace, "badges")
+    print("Checking badge images...")
+    download_badges(badges_dir)
+
+    print("Building combined HTML...")
+    html = build_html(workspace, title)
+
+    html_path = os.path.join(workspace, "_report.html")
+    with open(html_path, 'w') as f:
+        f.write(html)
+
+    pdf_dir = os.path.join(workspace, "pdf")
+    os.makedirs(pdf_dir, exist_ok=True)
+    pdf_path = os.path.join(pdf_dir, f"{title}.pdf")
+
+    print(f"Exporting PDF: {pdf_path}")
+    result = subprocess.run([
+        browser,
+        "--headless", "--disable-gpu", "--no-sandbox",
+        f"--print-to-pdf={pdf_path}",
+        "--no-pdf-header-footer",
+        f"file://{html_path}",
+    ], capture_output=True, text=True)
+
+    # Clean up temp HTML
+    os.remove(html_path)
+
+    if os.path.exists(pdf_path):
+        # Remove macOS quarantine attribute (headless Edge adds it)
+        if sys.platform == 'darwin':
+            subprocess.run(['xattr', '-d', 'com.apple.quarantine', pdf_path],
+                           capture_output=True)
+        size_mb = os.path.getsize(pdf_path) / (1024 * 1024)
+        print(f"PDF generated: {pdf_path} ({size_mb:.1f} MB)")
+    else:
+        print(f"ERROR: PDF not created. Browser stderr: {result.stderr}")
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/skills/agent-academy-report/scripts/extract_feedback.py
+++ b/.github/skills/agent-academy-report/scripts/extract_feedback.py
@@ -1,0 +1,145 @@
+#!/usr/bin/env python3
+"""Extract feedback data from Excel files in the workspace data/ folder.
+
+Usage: python3 extract_feedback.py <workspace-path>
+
+Reads all .xlsx files from <workspace>/data/, extracts feedback text,
+completion dates, and respondent names. Outputs <workspace>/data/_extracted.json.
+"""
+
+import openpyxl
+import os
+import sys
+import re
+import json
+import glob
+from datetime import datetime
+
+
+COURSE_NAME_MAP = {
+    "Agent Academy - Special Ops_ YAML Specialist": "Special Ops: YAML Specialist",
+    "Agent Academy - Special Ops_Microsoft Copilot Studio ❤️ MCP Mission Completion": "Special Ops: Microsoft Copilot Studio MCP",
+    "Agent Academy - Special Ops_ Microsoft Learn Docs MCP Server": "Special Ops: Microsoft Learn Docs MCP Server",
+    "Agent Academy - Special Ops_⚡ Power Platform CLI MCP Server": "Special Ops: Power Platform CLI MCP Server",
+    "Copilot Studio Agent Academy - Operative": "Operative",
+    "Copilot Studio Agent Academy - Recruit": "Recruit",
+    "Cowork Collective_ Badge Check Mission Completion": "Cowork Collective: Badge Check",
+    "Cowork Collective_ Compliance Packet Mission Completion": "Cowork Collective: Compliance Packet",
+    "Cowork Collective_ Out of Office Mission Completion": "Cowork Collective: Out of Office",
+}
+
+SKIP_PATTERNS = [r'^(no|none|n/?a|nothing|nope|-|\.+|\*+|ok|okay)$']
+
+
+def get_course_name(filename):
+    base = os.path.basename(filename)
+    base = re.sub(r'\(\d+-\d+\)\.xlsx$', '', base).strip().replace('\xa0', ' ')
+    return COURSE_NAME_MAP.get(base, base)
+
+
+def get_name_or_email(row_dict):
+    name = row_dict.get('Name')
+    if name and isinstance(name, str) and name.strip() and name.strip().lower() != 'anonymous':
+        return name.strip()
+    for key in ['Email address', 'What is your email address?']:
+        email = row_dict.get(key)
+        if email and isinstance(email, str) and email.strip():
+            return re.sub(r'[._]', ' ', email.strip().split('@')[0]).title()
+    return "Anonymous"
+
+
+def extract_file(filepath):
+    """Extract records from a single Excel file."""
+    course = get_course_name(filepath)
+    wb = openpyxl.load_workbook(filepath, data_only=True)
+    ws = wb.active
+
+    headers = [ws.cell(row=1, column=c).value for c in range(1, ws.max_column + 1)]
+
+    # Find feedback and completion time columns
+    feedback_cols = [i for i, h in enumerate(headers) if h and 'feedback' in str(h).lower()]
+    completion_col = next(
+        (i for i, h in enumerate(headers) if h and 'completion time' in str(h).lower()),
+        None
+    )
+
+    records = []
+
+    if not feedback_cols:
+        # No feedback column (Operative/Recruit) — extract completions only
+        for row_num in range(2, ws.max_row + 1):
+            dt = ws.cell(row=row_num, column=(completion_col or 1) + 1).value if completion_col is not None else None
+            if isinstance(dt, datetime):
+                records.append({
+                    'course': course,
+                    'date': dt.strftime('%Y-%m-%d'),
+                    'month': dt.strftime('%Y-%m'),
+                    'sentiment': None,
+                    'text': None,
+                    'name': None,
+                    'type': 'completion',
+                })
+        wb.close()
+        return records
+
+    for row_num in range(2, ws.max_row + 1):
+        row_values = {h: ws.cell(row=row_num, column=ci + 1).value for ci, h in enumerate(headers) if h}
+        dt = ws.cell(row=row_num, column=(completion_col or 1) + 1).value if completion_col is not None else None
+        date_str = dt.strftime('%Y-%m-%d') if isinstance(dt, datetime) else None
+        month_str = dt.strftime('%Y-%m') if isinstance(dt, datetime) else None
+        name = get_name_or_email(row_values)
+
+        for fc in feedback_cols:
+            text = ws.cell(row=row_num, column=fc + 1).value
+            if not text or not isinstance(text, str) or len(text.strip()) < 5:
+                continue
+            if any(re.match(sp, text.strip(), re.IGNORECASE) for sp in SKIP_PATTERNS):
+                continue
+            records.append({
+                'course': course,
+                'date': date_str,
+                'month': month_str,
+                'sentiment': None,
+                'text': text.strip(),
+                'name': name,
+                'type': 'feedback',
+            })
+
+    wb.close()
+    return records
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python3 extract_feedback.py <workspace-path>")
+        sys.exit(1)
+
+    workspace = sys.argv[1]
+    data_dir = os.path.join(workspace, "data")
+
+    files = sorted(glob.glob(os.path.join(data_dir, "*.xlsx")))
+    if not files:
+        print(f"No .xlsx files found in {data_dir}")
+        sys.exit(1)
+
+    all_records = []
+    for f in files:
+        course = get_course_name(f)
+        records = extract_file(f)
+        all_records.extend(records)
+        feedback_count = sum(1 for r in records if r['type'] == 'feedback')
+        completion_count = sum(1 for r in records if r['type'] == 'completion')
+        print(f"  {course}: {feedback_count} feedback, {completion_count} completions")
+
+    output_path = os.path.join(data_dir, "_extracted.json")
+    with open(output_path, 'w') as f:
+        json.dump(all_records, f, indent=2, default=str)
+
+    total_feedback = sum(1 for r in all_records if r['type'] == 'feedback')
+    total_completions = sum(1 for r in all_records if r['type'] == 'completion')
+    print(f"\nTotal: {total_feedback} feedback items, {total_completions} completions")
+    print(f"Saved to {output_path}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.github/skills/agent-academy-report/scripts/generate_charts.py
+++ b/.github/skills/agent-academy-report/scripts/generate_charts.py
@@ -1,0 +1,362 @@
+#!/usr/bin/env python3
+"""Generate charts from analyzed feedback data.
+
+Usage: python3 generate_charts.py <workspace-path>
+
+Reads <workspace>/data/_analyzed.json and generates 6 chart PNGs
+in <workspace>/charts/.
+"""
+
+import json
+import os
+import sys
+from datetime import datetime, timedelta
+from collections import defaultdict
+
+import numpy as np
+import matplotlib
+matplotlib.use('Agg')
+import matplotlib.pyplot as plt
+import matplotlib.dates as mdates
+import matplotlib.patheffects as pe
+from matplotlib.patches import FancyBboxPatch
+
+# Modern color palette (navy/teal theme matching the cover)
+NAVY = '#111827'
+NAVY_LIGHT = '#1e293b'
+TEAL = '#2dd4bf'
+TEAL_DARK = '#14b8a6'
+BLUE = '#3b82f6'
+GREEN = '#22c55e'
+RED = '#ef4444'
+ORANGE = '#f59e0b'
+PURPLE = '#a78bfa'
+SLATE = '#94a3b8'
+SLATE_LIGHT = '#cbd5e1'
+BG_COLOR = '#fafbfc'
+GRID_COLOR = '#e2e8f0'
+
+COURSE_GROUPS = {
+    'Recruit': BLUE,
+    'Operative': TEAL_DARK,
+    'Special Ops': ORANGE,
+    'Cowork Collective': PURPLE,
+}
+
+SHORT_NAMES = {
+    "Special Ops: YAML Specialist": "YAML Specialist",
+    "Special Ops: Microsoft Copilot Studio MCP": "Copilot Studio MCP",
+    "Special Ops: Microsoft Learn Docs MCP Server": "Learn Docs MCP",
+    "Special Ops: Power Platform CLI MCP Server": "PP CLI MCP",
+    "Cowork Collective: Badge Check": "Badge Check",
+    "Cowork Collective: Compliance Packet": "Compliance Packet",
+    "Cowork Collective: Out of Office": "Out of Office",
+}
+
+COURSE_ORDER = [
+    "Recruit", "Operative",
+    "Special Ops: YAML Specialist", "Special Ops: Microsoft Copilot Studio MCP",
+    "Special Ops: Microsoft Learn Docs MCP Server", "Special Ops: Power Platform CLI MCP Server",
+    "Cowork Collective: Badge Check", "Cowork Collective: Compliance Packet", "Cowork Collective: Out of Office",
+]
+
+
+def setup_style():
+    plt.rcParams.update({
+        'font.family': 'sans-serif',
+        'font.sans-serif': ['Helvetica Neue', 'Helvetica', 'Arial', 'sans-serif'],
+        'font.size': 11,
+        'axes.spines.top': False,
+        'axes.spines.right': False,
+        'axes.spines.left': True,
+        'axes.spines.bottom': True,
+        'axes.edgecolor': SLATE_LIGHT,
+        'axes.linewidth': 0.8,
+        'axes.facecolor': BG_COLOR,
+        'figure.facecolor': 'white',
+        'axes.grid': True,
+        'grid.color': GRID_COLOR,
+        'grid.linewidth': 0.5,
+        'grid.alpha': 0.7,
+        'axes.axisbelow': True,
+        'xtick.color': SLATE,
+        'ytick.color': SLATE,
+        'text.color': NAVY,
+    })
+
+
+def chart_completions_over_time(records, charts_dir):
+    """Area chart of weekly completions by course group."""
+    weekly = defaultdict(lambda: defaultdict(int))
+    for r in records:
+        if r.get('date'):
+            dt = datetime.strptime(r['date'], '%Y-%m-%d')
+            week_start = dt - timedelta(days=dt.weekday())
+            weekly[week_start.strftime('%Y-%m-%d')][r['course']] += 1
+
+    weeks_sorted = sorted(weekly.keys())
+    week_dates = [datetime.strptime(w, '%Y-%m-%d') for w in weeks_sorted]
+
+    group_data = {g: [] for g in COURSE_GROUPS}
+    for w in weeks_sorted:
+        for group in COURSE_GROUPS:
+            count = sum(v for k, v in weekly[w].items() if k.startswith(group) or k == group)
+            group_data[group].append(count)
+
+    fig, ax = plt.subplots(figsize=(12, 5))
+
+    # Stacked area chart
+    values_list = [np.array(group_data[g]) for g in COURSE_GROUPS]
+    colors = list(COURSE_GROUPS.values())
+    labels = list(COURSE_GROUPS.keys())
+    ax.stackplot(week_dates, *values_list, labels=labels, colors=colors, alpha=0.75, edgecolor='white', linewidth=0.5)
+
+    ax.set_title('Course Completions Over Time', fontsize=16, fontweight='bold', pad=15, color=NAVY)
+    ax.set_ylabel('Weekly Completions', fontsize=11, color=SLATE)
+    ax.legend(loc='upper left', framealpha=0.95, edgecolor=GRID_COLOR, fancybox=True)
+    ax.xaxis.set_major_formatter(mdates.DateFormatter('%b %d'))
+    ax.xaxis.set_major_locator(mdates.WeekdayLocator(interval=2))
+    plt.xticks(rotation=45, ha='right')
+    ax.set_xlim(week_dates[0], week_dates[-1])
+    plt.tight_layout()
+    plt.savefig(os.path.join(charts_dir, 'completions_over_time.png'), dpi=180, bbox_inches='tight', facecolor='white')
+    plt.close()
+    print("  completions_over_time.png")
+
+
+def chart_sentiment_by_course(feedback, course_stats, charts_dir):
+    """Modern horizontal stacked bar of sentiment percentages per course with rounded styling."""
+    courses_with_data = [c for c in COURSE_ORDER if c in course_stats]
+    labels = [SHORT_NAMES.get(c, c) for c in courses_with_data]
+
+    pos_vals, neu_vals, neg_vals = [], [], []
+    for c in courses_with_data:
+        s = course_stats[c]
+        t = s['total']
+        pos_vals.append(s['positive'] / t * 100)
+        neu_vals.append(s['neutral'] / t * 100)
+        neg_vals.append(s['negative'] / t * 100)
+
+    fig, ax = plt.subplots(figsize=(10, 5.5))
+    y = np.arange(len(labels))
+    bar_height = 0.55
+
+    # Draw bars with slight rounded look
+    bars_pos = ax.barh(y, pos_vals, height=bar_height, color=GREEN, label='Positive', zorder=3, edgecolor='white', linewidth=0.5)
+    bars_neu = ax.barh(y, neu_vals, left=pos_vals, height=bar_height, color=SLATE_LIGHT, label='Neutral', zorder=3, edgecolor='white', linewidth=0.5)
+    bars_neg = ax.barh(y, neg_vals, left=[p + n for p, n in zip(pos_vals, neu_vals)], height=bar_height, color=RED, label='Negative', zorder=3, edgecolor='white', linewidth=0.5)
+
+    ax.set_yticks(y)
+    ax.set_yticklabels(labels, fontsize=11)
+    ax.set_xlabel('Percentage (%)', fontsize=11, color=SLATE)
+    ax.set_title('Sentiment Distribution by Course', fontsize=16, fontweight='bold', pad=15, color=NAVY)
+    ax.legend(loc='lower right', framealpha=0.95, edgecolor=GRID_COLOR, fancybox=True, fontsize=10)
+    ax.set_xlim(0, 105)
+    ax.invert_yaxis()
+    ax.spines['left'].set_visible(False)
+    ax.tick_params(axis='y', length=0)
+
+    for i, (p, n) in enumerate(zip(pos_vals, neg_vals)):
+        ax.text(p / 2, i, f'{p:.0f}%', ha='center', va='center', fontsize=9, fontweight='bold', color='white')
+        if n >= 5:
+            left = pos_vals[i] + neu_vals[i] + n / 2
+            ax.text(left, i, f'{n:.0f}%', ha='center', va='center', fontsize=8, fontweight='bold', color='white')
+
+    plt.tight_layout()
+    plt.savefig(os.path.join(charts_dir, 'sentiment_by_course.png'), dpi=180, bbox_inches='tight', facecolor='white')
+    plt.close()
+    print("  sentiment_by_course.png")
+
+
+def chart_grades(course_stats, charts_dir):
+    """Lollipop chart of course grades, sorted best to worst."""
+    courses_with_data = [c for c in COURSE_ORDER if c in course_stats]
+    # Sort by grade descending (best at top)
+    courses_with_data.sort(key=lambda c: course_stats[c]['grade'], reverse=True)
+    labels = [SHORT_NAMES.get(c, c) for c in courses_with_data]
+    grade_vals = [course_stats[c]['grade'] for c in courses_with_data]
+    colors = [GREEN if g >= 9 else (BLUE if g >= 8 else (ORANGE if g >= 7 else RED)) for g in grade_vals]
+
+    fig, ax = plt.subplots(figsize=(10, 5.5))
+    y = np.arange(len(labels))
+
+    # Draw stems
+    for i, (grade, color) in enumerate(zip(grade_vals, colors)):
+        ax.plot([0, grade], [i, i], color=color, linewidth=2, alpha=0.4, zorder=2)
+
+    # Draw dots
+    ax.scatter(grade_vals, y, c=colors, s=120, zorder=3, edgecolors='white', linewidth=1.5)
+
+    # Reference line at 8.0
+    ax.axvline(x=8, color=SLATE_LIGHT, linestyle='--', linewidth=1, zorder=1)
+    ax.text(8.02, -0.6, 'Target: 8.0', fontsize=9, color=SLATE, ha='left')
+
+    ax.set_yticks(y)
+    ax.set_yticklabels(labels, fontsize=11)
+    ax.set_xlabel('Grade (1–10)', fontsize=11, color=SLATE)
+    ax.set_title('Course Grades', fontsize=16, fontweight='bold', pad=15, color=NAVY)
+    ax.set_xlim(5, 10.5)
+    ax.invert_yaxis()
+    ax.spines['left'].set_visible(False)
+    ax.tick_params(axis='y', length=0)
+
+    for i, (v, c) in enumerate(zip(grade_vals, colors)):
+        ax.text(v + 0.12, i, f'{v}', ha='left', va='center', fontsize=12, fontweight='bold', color=c)
+
+    plt.tight_layout()
+    plt.savefig(os.path.join(charts_dir, 'grades_by_course.png'), dpi=180, bbox_inches='tight', facecolor='white')
+    plt.close()
+    print("  grades_by_course.png")
+
+
+def chart_cumulative(records, charts_dir):
+    """Line chart with gradient fill of cumulative completions over time."""
+    all_dates = sorted(set(r['date'] for r in records if r.get('date')))
+    date_objs = [datetime.strptime(d, '%Y-%m-%d') for d in all_dates]
+
+    fig, ax = plt.subplots(figsize=(12, 5))
+    for group, color in COURSE_GROUPS.items():
+        running = 0
+        cum = []
+        for d in all_dates:
+            running += sum(1 for r in records if r.get('date') == d and (r['course'].startswith(group) or r['course'] == group))
+            cum.append(running)
+        line, = ax.plot(date_objs, cum, label=group, color=color, linewidth=2.5, zorder=3)
+        ax.fill_between(date_objs, cum, alpha=0.08, color=color, zorder=2)
+        if cum:
+            ax.scatter([date_objs[-1]], [cum[-1]], color=color, s=50, zorder=4, edgecolors='white', linewidth=1.5)
+            ax.text(date_objs[-1], cum[-1], f'  {cum[-1]:,}', va='center', fontsize=10, color=color, fontweight='bold')
+
+    ax.set_title('Cumulative Course Completions', fontsize=16, fontweight='bold', pad=15, color=NAVY)
+    ax.set_ylabel('Total Completions', fontsize=11, color=SLATE)
+    ax.legend(loc='upper left', framealpha=0.95, edgecolor=GRID_COLOR, fancybox=True)
+    ax.xaxis.set_major_formatter(mdates.DateFormatter('%b %Y'))
+    ax.xaxis.set_major_locator(mdates.MonthLocator())
+    plt.xticks(rotation=45, ha='right')
+    ax.set_xlim(date_objs[0], date_objs[-1])
+    plt.tight_layout()
+    plt.savefig(os.path.join(charts_dir, 'cumulative_completions.png'), dpi=180, bbox_inches='tight', facecolor='white')
+    plt.close()
+    print("  cumulative_completions.png")
+
+
+def chart_sentiment_pie(feedback, charts_dir):
+    """Donut chart of overall sentiment distribution."""
+    total_pos = sum(1 for r in feedback if r['sentiment'] == 'positive')
+    total_neu = sum(1 for r in feedback if r['sentiment'] == 'neutral')
+    total_neg = sum(1 for r in feedback if r['sentiment'] == 'negative')
+    total = total_pos + total_neu + total_neg
+
+    fig, ax = plt.subplots(figsize=(6, 6))
+    sizes = [total_pos, total_neu, total_neg]
+    labels = ['Positive', 'Neutral', 'Negative']
+    colors = [GREEN, SLATE_LIGHT, RED]
+
+    wedges, texts, autotexts = ax.pie(
+        sizes, labels=None, colors=colors, autopct='%1.0f%%',
+        startangle=90, pctdistance=0.82,
+        wedgeprops=dict(width=0.35, edgecolor='white', linewidth=2),
+        textprops={'fontsize': 12, 'fontweight': 'bold'}
+    )
+    for at in autotexts:
+        at.set_color('white')
+        at.set_fontsize(12)
+        at.set_fontweight('bold')
+
+    # Center text
+    ax.text(0, 0.06, f'{total:,}', ha='center', va='center', fontsize=28, fontweight='bold', color=NAVY)
+    ax.text(0, -0.12, 'responses', ha='center', va='center', fontsize=11, color=SLATE)
+
+    # Legend
+    legend_labels = [f'{l} ({s:,})' for l, s in zip(labels, sizes)]
+    ax.legend(wedges, legend_labels, loc='lower center', bbox_to_anchor=(0.5, -0.08),
+              framealpha=0.95, edgecolor=GRID_COLOR, fancybox=True, fontsize=11, ncol=3)
+
+    ax.set_title('Overall Feedback Sentiment', fontsize=16, fontweight='bold', pad=15, color=NAVY)
+    plt.tight_layout()
+    plt.savefig(os.path.join(charts_dir, 'sentiment_pie.png'), dpi=180, bbox_inches='tight', facecolor='white')
+    plt.close()
+    print("  sentiment_pie.png")
+
+
+def chart_monthly_feedback(records, charts_dir):
+    """Modern stacked bar of monthly submissions by course group."""
+    monthly = defaultdict(lambda: defaultdict(int))
+    for r in records:
+        if r.get('date'):
+            month = r['date'][:7]
+            for group in COURSE_GROUPS:
+                if r['course'].startswith(group) or r['course'] == group:
+                    monthly[month][group] += 1
+                    break
+
+    months_sorted = sorted(monthly.keys())
+    month_labels = [datetime.strptime(m + '-01', '%Y-%m-%d').strftime('%b %Y') for m in months_sorted]
+
+    fig, ax = plt.subplots(figsize=(12, 6))
+    x = np.arange(len(months_sorted))
+    bar_width = 0.55
+    bottom = np.zeros(len(months_sorted))
+
+    for group, color in COURSE_GROUPS.items():
+        values = np.array([monthly[m][group] for m in months_sorted])
+        bars = ax.bar(x, values, bar_width, bottom=bottom, label=group, color=color,
+                      edgecolor='white', linewidth=0.5, zorder=3)
+        for i, (bar, val) in enumerate(zip(bars, values)):
+            if val >= 15:
+                ax.text(bar.get_x() + bar.get_width() / 2, bottom[i] + val / 2,
+                        str(val), ha='center', va='center', fontsize=8, fontweight='bold', color='white')
+        bottom += values
+
+    # Total labels on top
+    for i, total in enumerate(bottom):
+        if total > 0:
+            ax.text(x[i], total + 3, f'{int(total):,}', ha='center', va='bottom', fontsize=9, fontweight='bold', color=NAVY)
+
+    ax.set_title('Monthly Submissions by Course', fontsize=16, fontweight='bold', pad=15, color=NAVY)
+    ax.set_ylabel('Submissions', fontsize=11, color=SLATE)
+    ax.set_xticks(x)
+    ax.set_xticklabels(month_labels, rotation=45, ha='right')
+    ax.legend(loc='upper left', framealpha=0.95, edgecolor=GRID_COLOR, fancybox=True)
+    ax.spines['bottom'].set_visible(False)
+    ax.tick_params(axis='x', length=0)
+    plt.tight_layout()
+    plt.savefig(os.path.join(charts_dir, 'monthly_feedback.png'), dpi=180, bbox_inches='tight', facecolor='white')
+    plt.close()
+    print("  monthly_feedback.png")
+
+
+def main():
+    if len(sys.argv) < 2:
+        print("Usage: python3 generate_charts.py <workspace-path>")
+        sys.exit(1)
+
+    workspace = sys.argv[1]
+    charts_dir = os.path.join(workspace, "charts")
+    os.makedirs(charts_dir, exist_ok=True)
+
+    data_path = os.path.join(workspace, "data", "_analyzed.json")
+    if not os.path.exists(data_path):
+        print(f"No analyzed data found. Run analyze_sentiment.py first.")
+        sys.exit(1)
+
+    with open(data_path) as f:
+        data = json.load(f)
+
+    records = data['records']
+    course_stats = data['course_stats']
+    feedback = [r for r in records if r['type'] == 'feedback']
+
+    setup_style()
+    print("Generating charts...")
+    chart_completions_over_time(records, charts_dir)
+    chart_sentiment_by_course(feedback, course_stats, charts_dir)
+    chart_grades(course_stats, charts_dir)
+    chart_cumulative(records, charts_dir)
+    chart_sentiment_pie(feedback, charts_dir)
+    chart_monthly_feedback(records, charts_dir)
+    print(f"\nAll 6 charts saved to {charts_dir}")
+
+
+if __name__ == "__main__":
+    main()

--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ docs/.vitepress/cache
 
 # VitePress root cache
 /.vitepress/
+
+# Report output
+report/


### PR DESCRIPTION
## Summary

Adds the **agent-academy-report** skill for generating comprehensive feedback analysis reports for Agent Academy.

### Changes
- **New skill**: `.github/skills/agent-academy-report/skill.md` — skill definition with consistent `<workspace>/report/` paths
- **Python scripts** for the 5-phase report pipeline:
  - `extract_feedback.py` — Extract feedback from Excel files
  - `analyze_sentiment.py` — Keyword-based sentiment scoring
  - `generate_charts.py` — Chart generation with matplotlib
  - `build_markdown.py` — Markdown report generation
  - `export_pdf.py` — PDF export via headless Edge/Chrome
- **`.gitignore`** — Added `report/` directory for local output