### PR TITLE
feat: enhance report with per-course charts, comparison table, next s…

### DIFF
--- a/.github/skills/agent-academy-report/SKILL.md
+++ b/.github/skills/agent-academy-report/SKILL.md
@@ -24,13 +24,14 @@ If the user provides a workspace path, use it. Otherwise, ask for it.
 
 ## Overview
 
-The report generation has 5 phases:
+The report generation has 6 phases:
 
 1. **Extract feedback** from Excel files and GitHub issues
 2. **Analyze sentiment** using keyword-based scoring
 3. **Generate charts** with matplotlib
 4. **Build markdown** files (management summary + detailed analysis)
 5. **Export a single PDF** with cover page, management summary, and full analysis
+6. **Verify PDF formatting** — visually inspect and fix any layout issues
 
 Run the bundled Python scripts in order. Each script is self-contained and reads/writes to the folder structure above.
 
@@ -428,7 +429,63 @@ The script checks these browser paths in order and uses the first one found:
 
 ---
 
-## Course Name Mapping
+## Phase 6: Verify PDF Formatting
+
+After generating the PDF, **always** open and visually inspect it to check for formatting issues. Use the `view_image` tool or open the PDF to review each page.
+
+### Verification Checklist
+
+Check the following and fix any issues found:
+
+| Check                       | What to look for                                                                                 | Fix location                                                                      |
+| --------------------------- | ------------------------------------------------------------------------------------------------ | --------------------------------------------------------------------------------- |
+| **Cover page**              | Logo centered, title/subtitle readable, badges displayed in a row, no overflow                   | `export_pdf.py` CSS                                                               |
+| **Sentiment pie chart**     | Should be ~45% width, centered — NOT stretched full-width                                        | `export_pdf.py` `embed_md_images()` — use `max-width:45%` for `sentiment_pie`     |
+| **Per-course charts**       | Should be ~85% width, not full-width blowups                                                     | `export_pdf.py` `embed_md_images()` — use `max-width:85%` for `course_` charts    |
+| **h2 section starts**       | Each h2 (Recruit, Operative, Special Ops, Cowork Collective) should start on a new page in print | `export_pdf.py` `@media print` — `h2 { page-break-before: always }`               |
+| **First h2 after h1**       | Should NOT page-break (it follows right after the section title)                                 | `.content > h2:first-of-type { page-break-before: avoid }`                        |
+| **No orphan headings**      | h2/h3/h4 should not appear alone at bottom of a page                                             | `h2, h3, h4 { page-break-after: avoid }`                                          |
+| **Tables not split**        | Tables should not break across pages                                                             | `table { page-break-inside: avoid }`                                              |
+| **Blockquotes not split**   | Quotes should stay on one page                                                                   | `blockquote { page-break-inside: avoid }`                                         |
+| **Section-level summaries** | Cross-mission themes and next steps should use proper `###` headings, not bold inline text       | `build_markdown.py` — use `### Cross-Mission Themes` and `### Section Next Steps` |
+| **Line breaks**             | Stats line, themes, and next steps should be visually separated (not running together)           | `build_markdown.py` — ensure `\n\n` between sections                              |
+| **Funnel table**            | Submission pipeline table renders correctly with indented rows                                   | `build_markdown.py` `_build_comparison_table()`                                   |
+
+### Common Formatting Issues & Fixes
+
+**Chart too large / stretched:**
+The `embed_md_images()` function in `export_pdf.py` controls image sizing. It matches filenames to determine width:
+
+- `sentiment_pie` → `max-width:45%` (small donut chart)
+- `course_*` → `max-width:85%` (per-course charts)
+- Everything else → `max-width:100%` (overview charts)
+
+If a chart looks wrong, adjust the `SMALL_CHARTS` or `MEDIUM_CHARTS` lists and the corresponding `max-width` percentages.
+
+**Heading appears alone at page bottom:**
+This means `page-break-after: avoid` is not being respected (can happen with large content blocks). Wrap the heading + its following content in a `<div class="keep-together">` block in `md_to_html()`.
+
+**Content runs together without spacing:**
+The markdown-to-HTML converter treats `\n\n` as paragraph breaks (`<p>`). If content runs together, add an extra blank line in the markdown output (`build_markdown.py`). Use proper `###` headings instead of `**bold text:**` for visually distinct sections.
+
+**h2 doesn't start on new page:**
+Only works in `@media print`. The `:first-of-type` selector prevents the first h2 in each `.content` div from page-breaking. If ALL h2s page-break when they shouldn't, check that the CSS selector is scoped correctly.
+
+### Re-export After Fixes
+
+If any formatting issues are found and fixed in the Python scripts, re-run the affected steps:
+
+```bash
+# If build_markdown.py was changed:
+python3 <skill-path>/scripts/build_markdown.py "<workspace>/report"
+
+# Always re-export PDF after any fix:
+python3 <skill-path>/scripts/export_pdf.py "<workspace>/report" "<report-title>"
+```
+
+Then verify again until all checks pass.
+
+---
 
 Excel filenames map to display names as follows:
 
@@ -472,6 +529,10 @@ python3 <skill-path>/scripts/build_markdown.py "<workspace>/report"
 
 # 6. Export PDF
 python3 <skill-path>/scripts/export_pdf.py "<workspace>/report" "Agent Academy - Report April 2026"
+
+# 7. Verify PDF formatting
+#    Open the PDF and check: cover page, chart sizes, page breaks, spacing
+#    Fix any issues in export_pdf.py or build_markdown.py, then re-export
 ```
 
 Step 2 requires the GitHub MCP tools and should be done interactively by the agent between steps 1 and 3.

--- a/.github/skills/agent-academy-report/SKILL.md
+++ b/.github/skills/agent-academy-report/SKILL.md
@@ -49,6 +49,8 @@ This script:
 - Reads all `.xlsx` files from `<workspace>/report/data/`
 - Maps filenames to human-readable course names
 - Extracts feedback text, completion dates, and respondent names/emails
+- **Name normalization**: If only an email address is available, it converts it to a display name — e.g. `john.doe@example.com` → `"John Doe"` (split on dots/underscores, title-cased). If neither a name nor email is found, the name defaults to `"Anonymous"`.
+- Skips trivial feedback entries (e.g. "no", "none", "n/a", "ok", single punctuation)
 - For files without a feedback column (Operative, Recruit), it extracts completion dates only — their feedback comes from GitHub issues
 - Outputs `<workspace>/report/data/_extracted.json`
 
@@ -112,6 +114,24 @@ Filter out issues that already have `recruit-completed` or `operative-completed`
 
 If no match is found, skip the issue. Set `source: "github_issue"` and `type: "feedback"` for these records. Use the issue title + body as the feedback text.
 
+### How Non-Badge Issues Are Used
+
+Non-badge GitHub issues (`source: "github_issue"`) are **included** in:
+
+- Sentiment analysis (scored and themed)
+- Course grades (affect positive/negative percentages)
+- Top themes (feed into per-course theme detection)
+- Representative quotes (can appear as selected quotes)
+- Next steps (negative themes from these issues drive recommendations)
+
+Non-badge GitHub issues are **excluded** from:
+
+- Submission/completion charts (completions over time, cumulative, monthly, per-course)
+- Monthly trend tables (submission counts)
+- Total completions count in the management summary
+
+This is because they are feedback and bug reports, not actual course completions.
+
 ### Recruit & Operative Comparison Data
 
 The combined `_all_feedback.json` will contain records with different `source` values. The build script uses these to generate a **Submission Pipeline** comparison table for Recruit and Operative:
@@ -136,18 +156,55 @@ python3 <skill-path>/scripts/analyze_sentiment.py "<workspace-path>/report"
 This script:
 
 - Reads `<workspace>/report/data/_all_feedback.json`
-- Scores each feedback item using keyword-based sentiment analysis
-- Detects common themes (Hands-on Learning, Setup Challenges, MCP Skills, etc.)
+- Scores each feedback item using regex-based sentiment analysis (word-boundary `\b` matching, case-insensitive)
+- Detects common themes and adds a `themes` array to each record (list of matched theme names, e.g. `["Hands-on & Practical Learning", "MCP & Agent Development Skills"]`)
 - Computes per-course grades using weighted average (positive=10, neutral=6, negative=2)
 - Outputs `<workspace>/report/data/_analyzed.json` with sentiment labels, themes, and course stats
 
+### Output Structure
+
+The `_analyzed.json` file contains:
+
+```json
+{
+  "records": [ ... ],        // All records with added "sentiment" and "themes" fields
+  "summary": { "total_records", "total_feedback", "positive", "neutral", "negative", "overall_grade" },
+  "course_stats": {           // Per-course: total, positive, neutral, negative, grade, themes (with counts)
+    "Recruit": { "total": 123, "positive": 100, ..., "themes": { "Hands-on & Practical Learning": 45, ... } }
+  }
+}
+```
+
 ### Sentiment Keywords
 
-**Positive** patterns include: great, excellent, amazing, awesome, helpful, useful, learned, clear, intuitive, practical, hands-on, well-structured, engaging, valuable, insightful, comprehensive, etc.
+All patterns use `\b` word boundaries for precise matching (e.g. `\bgreat\b` matches "great" but not "greater").
 
-**Negative** patterns include: error, issue, problem, bug, broke, crash, fail, stuck, struggle, missing, trouble, difficult, confusing, frustrating, unclear, improve, wish, lack, disappoint, etc.
+**Positive** patterns include: great, excellent, amazing, awesome, fantastic, wonderful, love/loved, enjoy/enjoyed, helpful, useful, informative, well done, good job, thank/thanks, appreciate, impressive, learned, learning, eye-opening, recommend, looking forward, fun, excited, brilliant, clear, intuitive, practical, hands-on, well-structured, well-organized, good, nice, cool, neat, super, stellar, outstanding, perfect, phenomenal, beginner-friendly, easy to follow, straightforward, engaging, interesting, valuable, insightful, comprehensive, thorough, solid, smooth.
+
+**Positive emojis** (also scored as positive): 👍 🎉 🙌 ❤️ 🔥 💯 ⭐ ✨ 😍 😊 🤩 💪
+
+**Negative** patterns include: error(s), issue(s), problem(s), bug(s)/buggy, broke/broken/crash/crashed, fail/failed/failure, didn't work, not work, couldn't, stuck, struggling/struggle, missing, trouble, difficult/difficulties, cumbersome, challenge(s), troubleshoot, confusing/confused, frustrating/frustrated, slow, complex, unclear, improve/improvement, wish, lack/lacking, disappoint/disappointed.
 
 **Scoring rule:** If negative matches > positive matches → negative. Else if positive > 0 → positive. Else if negative > 0 → negative. Else → neutral.
+
+### Theme Detection
+
+The analyzer detects 10 predefined themes by matching regex keywords against feedback text:
+
+| Theme                              | Keywords (regex)                                                                  |
+| ---------------------------------- | --------------------------------------------------------------------------------- |
+| Hands-on & Practical Learning      | hands-on, practical, interactive, step-by-step, real-world, exercise              |
+| Clear Instructions & Documentation | clear, well-document, well-explain, easy to follow, straightforward, instructions |
+| MCP & Agent Development Skills     | mcp, copilot studio, agent, connector, power automate, topic, action              |
+| Setup & Configuration Challenges   | setup, install, config, environment, prerequisite, authentication, credentials    |
+| VS Code Integration                | vs code, visual studio code, extension, editor, debug                             |
+| Valuable Learning Experience       | learn, knowledge, understand, skill, experience, educational, insight             |
+| Course Quality & Engagement        | well-design, engag, interest, quality, structure, organized, professional         |
+| Errors & Technical Issues          | error, bug, crash, broke, fail, fix, workaround                                   |
+| Improvement Suggestions            | improv, suggest, would be nice, could be, hope, wish, add more, future            |
+| Real-World Applicability           | real-world, production, business, enterprise, workplace, appl                     |
+
+A feedback item can match multiple themes. Themes are stored as `r['themes'] = [...]` on each record.
 
 ---
 
@@ -161,7 +218,34 @@ python3 <skill-path>/scripts/generate_charts.py "<workspace-path>/report"
 
 Requires `matplotlib` and `numpy`. Install if needed: `pip3 install matplotlib numpy`.
 
-This generates overview charts plus individual per-course charts in `<workspace>/report/charts/` at 180 DPI:
+This generates overview charts plus individual per-course charts in `<workspace>/report/charts/` at 180 DPI.
+
+**Note:** Submission/completion charts only count actual submissions (`source: "excel"` and `source: "github_completed"`). Non-badge GitHub issues (`source: "github_issue"`) are excluded from these charts — they are only used for sentiment analysis.
+
+### Course Grouping & Colors
+
+Charts group courses into 4 categories, each with a consistent color:
+
+| Group             | Color  | Hex     | Courses                        |
+| ----------------- | ------ | ------- | ------------------------------ |
+| Recruit           | Blue   | #3b82f6 | Recruit                        |
+| Operative         | Teal   | #14b8a6 | Operative                      |
+| Special Ops       | Orange | #f59e0b | All Special Ops missions       |
+| Cowork Collective | Purple | #a78bfa | All Cowork Collective missions |
+
+**Display order** (used in all charts): Recruit, Operative, Special Ops: YAML Specialist, Special Ops: Microsoft Copilot Studio MCP, Special Ops: Microsoft Learn Docs MCP Server, Special Ops: Power Platform CLI MCP Server, Cowork Collective: Badge Check, Cowork Collective: Compliance Packet, Cowork Collective: Out of Office.
+
+**Short names** used on chart axes (where full names are too long):
+
+| Full Name                                    | Short Name         |
+| -------------------------------------------- | ------------------ |
+| Special Ops: YAML Specialist                 | YAML Specialist    |
+| Special Ops: Microsoft Copilot Studio MCP    | Copilot Studio MCP |
+| Special Ops: Microsoft Learn Docs MCP Server | Learn Docs MCP     |
+| Special Ops: Power Platform CLI MCP Server   | PP CLI MCP         |
+| Cowork Collective: Badge Check               | Badge Check        |
+| Cowork Collective: Compliance Packet         | Compliance Packet  |
+| Cowork Collective: Out of Office             | Out of Office      |
 
 ### Overview Charts
 
@@ -181,7 +265,7 @@ For each course, a `course_{slug}.png` file is generated (e.g. `course_recruit.p
 - **Weekly submissions** as an area chart (primary axis)
 - **Cumulative total** as a dashed line (secondary axis)
 
-The slug is the course name lowercased with spaces → underscores and colons removed.
+The slug is the course name lowercased with spaces → underscores, colons removed, and ampersands → `"and"` (e.g. `"Cowork Collective: Badge Check"` → `course_cowork_collective_badge_check.png`).
 
 Color scheme (navy/teal theme matching cover): Blue (#3b82f6), Green (#22c55e), Red (#ef4444), Orange (#f59e0b), Purple (#a78bfa), Teal (#14b8a6). Charts use a consistent light background (#fafbfc), subtle grid (#e2e8f0), and navy (#111827) text.
 
@@ -201,15 +285,34 @@ This generates three markdown files in `<workspace>/report/markdown/`:
 
 - Title: "Management Summary"
 - Key metrics table (total completions, feedback count, courses, overall grade, sentiment percentages)
-- Highlights section
+  - **Total completions** excludes `source: "github_issue"` records (only counts actual submissions)
+- Highlights section (Recruit/Operative counts, highest/lowest rated courses)
 - Chart references (one per section with narrative text)
 - **Course Spotlights** section — for each course:
   - Grade, response count, positive/negative percentages
-  - Grade explanation (contextual note based on score range)
+  - Grade explanation — contextual note based on score range:
+    - ≥ 9.0: "Exceptional satisfaction — one of the top-rated courses."
+    - ≥ 8.5: "Strong satisfaction with consistently positive feedback."
+    - ≥ 8.0: "Good satisfaction, though some participants encountered challenges."
+    - < 8.0: "Solid course, but a higher neutral/negative ratio pulls the grade down."
   - Top 3 themes with mention counts
-  - Standout/watch area callout for notably high positive or negative rates
-  - Representative quotes — **10 total**, split proportionally to the grade (e.g., grade 8.0/10 → 8 positive, 2 negative)
-- Recommendations section
+  - **Standout callout** — appears when positive % ≥ 85%: highlights most-praised theme
+  - **Watch area callout** — appears when negative % ≥ 15%: highlights top negative theme
+  - Representative quotes — **10 total**, split proportionally to the grade using formula: `num_positive = round(10 × grade / 10)`. Grade 8.0/10 → 8 positive, 2 negative. Quotes are selected by closest to ideal length (positive: ~250 chars, negative: ~200 chars).
+- Recommendations section (4 static recommendations: address setup challenges, expand Cowork Collective, scale Special Ops, continue monitoring)
+
+#### Quote Cleaning
+
+All quotes in the report go through a cleaning pipeline before display:
+
+1. Newlines → spaces
+2. **Bold headers** (`**text**`) removed
+3. Markdown headers (`# ...`) removed
+4. Checkbox lines (`- [ ] ...`) removed
+5. Leading list dashes removed, inline dashes → periods
+6. HTML entities decoded (`&#39;` → `'`, `&amp;` → `&`)
+7. Collapsed whitespace
+8. Truncated at sentence boundary — positive quotes target ~250 chars max, negative quotes ~200 chars max (falls back to word boundary + `...` if no sentence break found above 80–100 chars)
 
 ### feedback-analysis.md
 
@@ -222,8 +325,31 @@ This generates three markdown files in `<workspace>/report/markdown/`:
   - **Submissions Over Time** chart (per-course chart reference)
   - **Monthly trend table** showing submissions, sentiment breakdown, and grade per month
   - **Top 5 themes** with mention counts and positive/negative indicator
-  - **10 representative quotes** — balanced on grade (e.g., grade 8/10 → 8 positive, 2 negative); each truncated to ~200 characters
-  - **Next Steps** — up to 5 prioritized, actionable recommendations sorted from most important to least, based on negative themes, grade, and engagement data
+  - **10 representative quotes** — balanced on grade using same formula as management summary (`round(10 × grade / 10)` positive, remainder negative); each cleaned by the quote pipeline (see above); positive truncated to ~200 chars, negative to ~180 chars
+  - **Next Steps** — up to 5 prioritized, actionable recommendations generated algorithmically:
+
+#### Next Steps Algorithm
+
+Each course gets up to 5 next steps, generated in priority order:
+
+1. **Priority 1–2: Top negative themes** — The top 2 themes with the most negative mentions, but only if each has ≥ 3 negative mentions. Uses a theme→advice mapping:
+
+   | Theme                              | Advice                                                                                       |
+   | ---------------------------------- | -------------------------------------------------------------------------------------------- |
+   | Setup & Configuration Challenges   | Simplify setup — provide a pre-configured environment or improved quick-start guide...       |
+   | Errors & Technical Issues          | Fix reported bugs — audit the most common failure points and add troubleshooting guidance.   |
+   | Improvement Suggestions            | Act on improvement suggestions — review and prioritize the most-requested changes...         |
+   | Clear Instructions & Documentation | Improve documentation clarity — review step-by-step guides for completeness...               |
+   | VS Code Integration                | Improve VS Code experience — ensure extensions and tooling work seamlessly...                |
+   | MCP & Agent Development Skills     | Strengthen MCP/agent content — review labs where participants reported MCP-related issues... |
+   | Valuable Learning Experience       | Enhance learning depth — some participants felt the content could go deeper...               |
+   | Course Quality & Engagement        | Refine course structure — address pacing and engagement issues...                            |
+   | Hands-on & Practical Learning      | Improve hands-on exercises — ensure lab environments are reliable...                         |
+   | Real-World Applicability           | Add more real-world examples — participants want to see how skills apply to production...    |
+
+2. **Priority 3: Grade-based advice** — If grade < 8.0: "Boost course quality — current grade is below the 8.0 target." If grade < 8.5: "Target grade improvement — small refinements could push this above 8.5."
+3. **Priority 4: Leverage strengths** — Highlights the top positive theme: "Double down on [theme] — most praised aspect ([count] positive mentions)."
+4. **Priority 5: Engagement** — If < 50 responses: "Increase feedback volume — consider adding in-course feedback prompts." Otherwise: "Continue monitoring — maintain the feedback loop and review sentiment trends monthly."
 
 ### feedback.md
 
@@ -247,9 +373,11 @@ This script:
 
 1. Downloads badge images from `https://raw.githubusercontent.com/microsoft/agent-academy/main/docs/public/images/` to `<workspace>/report/badges/` (if not already present)
 2. Builds a single HTML file with:
-   - **Cover page**: Blue gradient background, Agent Academy logo, report title, all badge images
-   - **Management summary**: Converted from markdown with charts embedded as base64 images
-   - **Detailed analysis**: Concise per-course analysis with monthly trends, themes, and representative quotes
+   - **Cover page**: Dark navy gradient background with teal accent, grid overlay, Agent Academy logo, report title, all badge images
+     - **Title splitting**: The report title is split on `" - "` — the part before becomes the main title (large teal text), the part after becomes the subtitle (smaller slate text). E.g. `"Agent Academy - Report April 2026"` → main: `"Agent Academy"`, subtitle: `"Report April 2026"`.
+     - **Hardcoded elements**: "Mission Report" tag (top-right classification label), "Microsoft Copilot Studio" pre-title above the main title, "Earned Badges" label on the badge shelf, "microsoft/agent-academy • Comprehensive Feedback & Completion Analysis" footer text.
+   - **Management summary**: Converted from markdown with charts embedded as base64 images (H1 title stripped — the HTML provides its own)
+   - **Detailed analysis**: Concise per-course analysis with monthly trends, themes, and representative quotes (H1 title stripped)
 3. Exports to PDF using headless Microsoft Edge:
    ```bash
    "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge" \
@@ -283,11 +411,12 @@ Downloaded from `microsoft/agent-academy` repo at `docs/public/images/`:
 
 ### Edge Fallback
 
-If Microsoft Edge is not available at the default macOS path, check:
+The script checks these browser paths in order and uses the first one found:
 
-- `/usr/bin/microsoft-edge` (Linux)
-- `C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe` (Windows)
-- Google Chrome as an alternative (`/Applications/Google Chrome.app/Contents/MacOS/Google Chrome`)
+1. `/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge` (macOS)
+2. `/usr/bin/microsoft-edge` (Linux)
+3. `/Applications/Google Chrome.app/Contents/MacOS/Google Chrome` (macOS)
+4. `/usr/bin/google-chrome` (Linux)
 
 ---
 
@@ -295,17 +424,17 @@ If Microsoft Edge is not available at the default macOS path, check:
 
 Excel filenames map to display names as follows:
 
-| Filename Pattern                                               | Course Name                                  |
-| -------------------------------------------------------------- | -------------------------------------------- |
-| `Agent Academy - Special Ops_ YAML Specialist`                 | Special Ops: YAML Specialist                 |
-| `Agent Academy - Special Ops_Microsoft Copilot Studio...MCP`   | Special Ops: Microsoft Copilot Studio MCP    |
-| `Agent Academy - Special Ops_ Microsoft Learn Docs MCP Server` | Special Ops: Microsoft Learn Docs MCP Server |
-| `Agent Academy - Special Ops_⚡ Power Platform CLI MCP Server` | Special Ops: Power Platform CLI MCP Server   |
-| `Copilot Studio Agent Academy - Operative`                     | Operative                                    |
-| `Copilot Studio Agent Academy - Recruit`                       | Recruit                                      |
-| `Cowork Collective_ Badge Check`                               | Cowork Collective: Badge Check               |
-| `Cowork Collective_ Compliance Packet`                         | Cowork Collective: Compliance Packet         |
-| `Cowork Collective_ Out of Office`                             | Cowork Collective: Out of Office             |
+| Filename Pattern                                                                 | Course Name                                  |
+| -------------------------------------------------------------------------------- | -------------------------------------------- |
+| `Agent Academy - Special Ops_ YAML Specialist`                                   | Special Ops: YAML Specialist                 |
+| `Agent Academy - Special Ops_Microsoft Copilot Studio ❤️ MCP Mission Completion` | Special Ops: Microsoft Copilot Studio MCP    |
+| `Agent Academy - Special Ops_ Microsoft Learn Docs MCP Server`                   | Special Ops: Microsoft Learn Docs MCP Server |
+| `Agent Academy - Special Ops_⚡ Power Platform CLI MCP Server`                   | Special Ops: Power Platform CLI MCP Server   |
+| `Copilot Studio Agent Academy - Operative`                                       | Operative                                    |
+| `Copilot Studio Agent Academy - Recruit`                                         | Recruit                                      |
+| `Cowork Collective_ Badge Check Mission Completion`                              | Cowork Collective: Badge Check               |
+| `Cowork Collective_ Compliance Packet Mission Completion`                        | Cowork Collective: Compliance Packet         |
+| `Cowork Collective_ Out of Office Mission Completion`                            | Cowork Collective: Out of Office             |
 
 Note: filenames may contain non-breaking spaces (`\xa0`) — normalize these to regular spaces before matching.
 

--- a/.github/skills/agent-academy-report/SKILL.md
+++ b/.github/skills/agent-academy-report/SKILL.md
@@ -288,17 +288,20 @@ This generates three markdown files in `<workspace>/report/markdown/`:
   - **Total completions** excludes `source: "github_issue"` records (only counts actual submissions)
 - Highlights section (Recruit/Operative counts, highest/lowest rated courses)
 - Chart references (one per section with narrative text)
-- **Course Spotlights** section — for each course:
-  - Grade, response count, positive/negative percentages
-  - Grade explanation — contextual note based on score range:
-    - ≥ 9.0: "Exceptional satisfaction — one of the top-rated courses."
-    - ≥ 8.5: "Strong satisfaction with consistently positive feedback."
-    - ≥ 8.0: "Good satisfaction, though some participants encountered challenges."
-    - < 8.0: "Solid course, but a higher neutral/negative ratio pulls the grade down."
-  - Top 3 themes with mention counts
-  - **Standout callout** — appears when positive % ≥ 85%: highlights most-praised theme
-  - **Watch area callout** — appears when negative % ≥ 15%: highlights top negative theme
-  - Representative quotes — **10 total**, split proportionally to the grade using formula: `num_positive = round(10 × grade / 10)`. Grade 8.0/10 → 8 positive, 2 negative. Quotes are selected by closest to ideal length (positive: ~250 chars, negative: ~200 chars).
+- **4 main sections** — Recruit, Operative, Special Ops, Cowork Collective:
+  - **Single-course sections** (Recruit, Operative): spotlight content directly under the section heading
+  - **Multi-mission sections** (Special Ops, Cowork Collective): section-level summary first (combined grade, response count, cross-mission themes, section-level next steps), then individual mission spotlights as sub-sections with short names (e.g. "YAML Specialist" instead of "Special Ops: YAML Specialist")
+  - Each course/mission spotlight includes:
+    - Grade, response count, positive/negative percentages
+    - Grade explanation — contextual note based on score range:
+      - ≥ 9.0: "Exceptional satisfaction — one of the top-rated courses."
+      - ≥ 8.5: "Strong satisfaction with consistently positive feedback."
+      - ≥ 8.0: "Good satisfaction, though some participants encountered challenges."
+      - < 8.0: "Solid course, but a higher neutral/negative ratio pulls the grade down."
+    - Top 3 themes with mention counts
+    - **Standout callout** — appears when positive % ≥ 85%: highlights most-praised theme
+    - **Watch area callout** — appears when negative % ≥ 15%: highlights top negative theme
+    - Representative quotes — **10 total**, split proportionally to the grade using formula: `num_positive = round(10 × grade / 10)`. Grade 8.0/10 → 8 positive, 2 negative. Quotes are selected by closest to ideal length (positive: ~250 chars, negative: ~200 chars).
 - Recommendations section (4 static recommendations: address setup challenges, expand Cowork Collective, scale Special Ops, continue monitoring)
 
 #### Quote Cleaning
@@ -319,14 +322,19 @@ All quotes in the report go through a cleaning pipeline before display:
 - Title: "Detailed Feedback Analysis"
 - Overall summary table (sentiment counts + percentages)
 - Course overview table (responses, sentiment breakdown, grade per course)
-- **Recruit & Operative: Submission Pipeline** — comparison table showing GitHub badge submissions, Excel form submissions, badges awarded (closed issues), and other GitHub issues for Recruit and Operative
-- Per-course sections (multiple pages per course are fine) with:
-  - Response counts and sentiment percentages
-  - **Submissions Over Time** chart (per-course chart reference)
-  - **Monthly trend table** showing submissions, sentiment breakdown, and grade per month
-  - **Top 5 themes** with mention counts and positive/negative indicator
-  - **10 representative quotes** — balanced on grade using same formula as management summary (`round(10 × grade / 10)` positive, remainder negative); each cleaned by the quote pipeline (see above); positive truncated to ~200 chars, negative to ~180 chars
-  - **Next Steps** — up to 5 prioritized, actionable recommendations generated algorithmically:
+- **Recruit & Operative: Submission Pipeline** — funnel-style comparison table showing GitHub badge submissions, badges awarded/pending with percentages, Excel form submissions, and other GitHub issues. Includes a note explaining that GitHub and Excel are independent channels.
+- **4 main sections** — Recruit, Operative, Special Ops, Cowork Collective:
+  - **Single-course sections** (Recruit, Operative): analysis content directly under the `## Section` heading (h2), with subsections as h3
+  - **Multi-mission sections** (Special Ops, Cowork Collective):
+    - **Section-level summary** (under h2): combined response count + grade, cross-mission themes (top 5 with positive/negative indicators), section-level recommendations (up to 5 next steps based on aggregated data across all missions)
+    - **Per-mission blocks** (under h3): each mission gets its own analysis using the short name (e.g. "YAML Specialist", "Badge Check"), with sub-headings at h4 level
+  - Each course/mission block includes:
+    - Response counts and sentiment percentages
+    - **Submissions Over Time** chart (per-course chart reference)
+    - **Monthly trend table** showing submissions, sentiment breakdown, and grade per month
+    - **Top 5 themes** with mention counts and positive/negative indicator
+    - **10 representative quotes** — balanced on grade using same formula as management summary (`round(10 × grade / 10)` positive, remainder negative); each cleaned by the quote pipeline (see above); positive truncated to ~200 chars, negative to ~180 chars
+    - **Next Steps** — up to 5 prioritized, actionable recommendations generated algorithmically:
 
 #### Next Steps Algorithm
 

--- a/.github/skills/agent-academy-report/SKILL.md
+++ b/.github/skills/agent-academy-report/SKILL.md
@@ -45,6 +45,7 @@ python3 <skill-path>/scripts/extract_feedback.py "<workspace-path>/report"
 ```
 
 This script:
+
 - Reads all `.xlsx` files from `<workspace>/report/data/`
 - Maps filenames to human-readable course names
 - Extracts feedback text, completion dates, and respondent names/emails
@@ -56,11 +57,13 @@ This script:
 After running the extract script, fetch feedback from GitHub issues. **Do not use `mcp_github_mcp_search_issues`** — the search API caps results at 1,000, which is insufficient for Recruit (1,390+ issues). Instead, use `mcp_github_mcp_list_issues` which supports full GraphQL cursor pagination:
 
 **Recruit issues:**
+
 ```
 owner: "microsoft", repo: "agent-academy", labels: ["recruit-completed"], state: "all", perPage: 100
 ```
 
 **Operative issues:**
+
 ```
 owner: "microsoft", repo: "agent-academy", labels: ["operative-completed"], state: "all", perPage: 100
 ```
@@ -68,6 +71,7 @@ owner: "microsoft", repo: "agent-academy", labels: ["operative-completed"], stat
 Paginate through **all** pages using the `endCursor` from each response until `hasNextPage` is false. The API returns max 100 per page — Recruit requires ~14 pages, Operative ~4 pages. Do not stop early; collect every issue.
 
 For each issue, parse the body for structured sections:
+
 - `### Key Learnings and Takeaways`
 - `### Challenges Faced`
 - `### Final Thoughts`
@@ -76,7 +80,48 @@ Combine these sections as the feedback text. The `name` field should be a plain 
 
 Save the combined data (Excel + GitHub) to `<workspace>/report/data/_all_feedback.json`.
 
-Each record should have: `{course, date, month, sentiment, text, name, type}`.
+Each record should have: `{course, date, month, sentiment, text, name, type, source, is_closed}`.
+
+- `source`: `"excel"` (set automatically by extract script), `"github_completed"` (badge submission issues), or `"github_issue"` (non-badge issues)
+- `is_closed`: `true`/`false` — for GitHub records only; indicates whether the issue is closed (closed = badge awarded for completed issues)
+
+### Non-Badge GitHub Issues
+
+After collecting badge submission issues, also fetch **all other open issues** that are NOT badge submissions. These are bug reports, questions, and general feedback that should be classified into the correct course.
+
+Fetch issues without the completed labels:
+
+```
+owner: "microsoft", repo: "agent-academy", state: "all", perPage: 100
+```
+
+Filter out issues that already have `recruit-completed` or `operative-completed` labels. For each remaining issue, classify it to a course using this keyword map (match against issue title and labels, case-insensitive):
+
+| Keywords in title/labels           | Course                                       |
+| ---------------------------------- | -------------------------------------------- |
+| `recruit`                          | Recruit                                      |
+| `operative`                        | Operative                                    |
+| `commander`                        | Commander                                    |
+| `yaml`, `yaml specialist`          | Special Ops: YAML Specialist                 |
+| `copilot studio` AND `mcp`         | Special Ops: Microsoft Copilot Studio MCP    |
+| `learn docs`, `learn mcp`          | Special Ops: Microsoft Learn Docs MCP Server |
+| `cli`, `power platform cli`, `pac` | Special Ops: Power Platform CLI MCP Server   |
+| `badge check`                      | Cowork Collective: Badge Check               |
+| `compliance`                       | Cowork Collective: Compliance Packet         |
+| `out of office`, `vacay`           | Cowork Collective: Out of Office             |
+
+If no match is found, skip the issue. Set `source: "github_issue"` and `type: "feedback"` for these records. Use the issue title + body as the feedback text.
+
+### Recruit & Operative Comparison Data
+
+The combined `_all_feedback.json` will contain records with different `source` values. The build script uses these to generate a **Submission Pipeline** comparison table for Recruit and Operative:
+
+| Metric                   | How to count                                                       |
+| ------------------------ | ------------------------------------------------------------------ |
+| GitHub Badge Submissions | Records where `source = "github_completed"`                        |
+| Excel Form Submissions   | Records where `source = "excel"`                                   |
+| Badges Awarded           | Records where `source = "github_completed"` AND `is_closed = true` |
+| Other GitHub Issues      | Records where `source = "github_issue"`                            |
 
 ---
 
@@ -89,6 +134,7 @@ python3 <skill-path>/scripts/analyze_sentiment.py "<workspace-path>/report"
 ```
 
 This script:
+
 - Reads `<workspace>/report/data/_all_feedback.json`
 - Scores each feedback item using keyword-based sentiment analysis
 - Detects common themes (Hands-on Learning, Setup Challenges, MCP Skills, etc.)
@@ -115,16 +161,27 @@ python3 <skill-path>/scripts/generate_charts.py "<workspace-path>/report"
 
 Requires `matplotlib` and `numpy`. Install if needed: `pip3 install matplotlib numpy`.
 
-This generates 6 charts in `<workspace>/report/charts/` at 180 DPI:
+This generates overview charts plus individual per-course charts in `<workspace>/report/charts/` at 180 DPI:
 
-| Chart | Filename | Description |
-|-------|----------|-------------|
-| Weekly completions | `completions_over_time.png` | Stacked area chart by course group |
-| Sentiment by course | `sentiment_by_course.png` | Horizontal stacked bar with positive/negative % labels |
-| Course grades | `grades_by_course.png` | Lollipop chart sorted by grade (best → worst) |
-| Cumulative completions | `cumulative_completions.png` | Line chart with gradient fills and endpoint markers |
-| Overall sentiment | `sentiment_pie.png` | Donut chart with total count in center |
-| Monthly feedback volume | `monthly_feedback.png` | Stacked bar by month and course group |
+### Overview Charts
+
+| Chart                   | Filename                     | Description                                            |
+| ----------------------- | ---------------------------- | ------------------------------------------------------ |
+| Weekly completions      | `completions_over_time.png`  | Stacked area chart by course group                     |
+| Sentiment by course     | `sentiment_by_course.png`    | Horizontal stacked bar with positive/negative % labels |
+| Course grades           | `grades_by_course.png`       | Lollipop chart sorted by grade (best → worst)          |
+| Cumulative completions  | `cumulative_completions.png` | Line chart with gradient fills and endpoint markers    |
+| Overall sentiment       | `sentiment_pie.png`          | Donut chart with total count in center                 |
+| Monthly feedback volume | `monthly_feedback.png`       | Stacked bar by month and course group                  |
+
+### Per-Course Charts
+
+For each course, a `course_{slug}.png` file is generated (e.g. `course_recruit.png`, `course_operative.png`, `course_special_ops_yaml_specialist.png`). Each shows:
+
+- **Weekly submissions** as an area chart (primary axis)
+- **Cumulative total** as a dashed line (secondary axis)
+
+The slug is the course name lowercased with spaces → underscores and colons removed.
 
 Color scheme (navy/teal theme matching cover): Blue (#3b82f6), Green (#22c55e), Red (#ef4444), Orange (#f59e0b), Purple (#a78bfa), Teal (#14b8a6). Charts use a consistent light background (#fafbfc), subtle grid (#e2e8f0), and navy (#111827) text.
 
@@ -141,6 +198,7 @@ python3 <skill-path>/scripts/build_markdown.py "<workspace-path>/report"
 This generates three markdown files in `<workspace>/report/markdown/`:
 
 ### management-summary.md
+
 - Title: "Management Summary"
 - Key metrics table (total completions, feedback count, courses, overall grade, sentiment percentages)
 - Highlights section
@@ -150,22 +208,27 @@ This generates three markdown files in `<workspace>/report/markdown/`:
   - Grade explanation (contextual note based on score range)
   - Top 3 themes with mention counts
   - Standout/watch area callout for notably high positive or negative rates
-  - Representative quotes — 5 total, split proportionally to the grade (e.g., grade 9.1 → 5 positive, 0 negative; grade 7.7 → 4 positive, 1 negative)
+  - Representative quotes — **10 total**, split proportionally to the grade (e.g., grade 8.0/10 → 8 positive, 2 negative)
 - Recommendations section
 
 ### feedback-analysis.md
+
 - Title: "Detailed Feedback Analysis"
 - Overall summary table (sentiment counts + percentages)
 - Course overview table (responses, sentiment breakdown, grade per course)
-- Per-course sections with:
+- **Recruit & Operative: Submission Pipeline** — comparison table showing GitHub badge submissions, Excel form submissions, badges awarded (closed issues), and other GitHub issues for Recruit and Operative
+- Per-course sections (multiple pages per course are fine) with:
   - Response counts and sentiment percentages
-  - Common themes (positive and negative)
-  - Individual feedback items sorted positive → neutral → negative
-  - Each item as a blockquote with sentiment emoji, quoted text, and attribution
-  - Horizontal rules between items
+  - **Submissions Over Time** chart (per-course chart reference)
+  - **Monthly trend table** showing submissions, sentiment breakdown, and grade per month
+  - **Top 5 themes** with mention counts and positive/negative indicator
+  - **10 representative quotes** — balanced on grade (e.g., grade 8/10 → 8 positive, 2 negative); each truncated to ~200 characters
+  - **Next Steps** — up to 5 prioritized, actionable recommendations sorted from most important to least, based on negative themes, grade, and engagement data
 
 ### feedback.md
+
 - Curated positive-only feedback (excludes error-mentioning entries)
+- **Max 5 quotes per course** (~45 total), selected for ideal length (~250 chars)
 - Each item as a blockquote: `> 👍 "text" — Name (Course)`
 
 ---
@@ -181,11 +244,12 @@ python3 <skill-path>/scripts/export_pdf.py "<workspace-path>/report" "<report-ti
 Example: `python3 scripts/export_pdf.py "/path/to/workspace/report" "Agent Academy - Report April 2026"`
 
 This script:
+
 1. Downloads badge images from `https://raw.githubusercontent.com/microsoft/agent-academy/main/docs/public/images/` to `<workspace>/report/badges/` (if not already present)
 2. Builds a single HTML file with:
    - **Cover page**: Blue gradient background, Agent Academy logo, report title, all badge images
    - **Management summary**: Converted from markdown with charts embedded as base64 images
-   - **Detailed analysis**: Full feedback analysis with all blockquotes and tables
+   - **Detailed analysis**: Concise per-course analysis with monthly trends, themes, and representative quotes
 3. Exports to PDF using headless Microsoft Edge:
    ```bash
    "/Applications/Microsoft Edge.app/Contents/MacOS/Microsoft Edge" \
@@ -202,6 +266,7 @@ The output PDF lands in `<workspace>/report/pdf/`.
 ### Page Break Rules
 
 The HTML includes CSS rules to prevent content from splitting across pages:
+
 - Charts + their descriptions are wrapped in `.chart-block` divs with `page-break-inside: avoid`
 - Course spotlight sections (h3 + content) are wrapped in `.course-spotlight` divs
 - Headings (`h2`, `h3`, `h4`) use `page-break-after: avoid`
@@ -210,6 +275,7 @@ The HTML includes CSS rules to prevent content from splitting across pages:
 ### Badge Images
 
 Downloaded from `microsoft/agent-academy` repo at `docs/public/images/`:
+
 - `logo.png` — Cover page logo
 - `mcs-agent-academy-recruit-badge.png`, `mcs-agent-academy-operative-badge.png`, `mcs-agent-academy-commander-badge.png` — Level badges
 - `YAML_Specialist_Badge.png`, `Academy_LearnMCP_Badge.png`, `CommandLine_Badge.png` — Special Ops badges
@@ -218,6 +284,7 @@ Downloaded from `microsoft/agent-academy` repo at `docs/public/images/`:
 ### Edge Fallback
 
 If Microsoft Edge is not available at the default macOS path, check:
+
 - `/usr/bin/microsoft-edge` (Linux)
 - `C:\Program Files (x86)\Microsoft\Edge\Application\msedge.exe` (Windows)
 - Google Chrome as an alternative (`/Applications/Google Chrome.app/Contents/MacOS/Google Chrome`)
@@ -228,17 +295,17 @@ If Microsoft Edge is not available at the default macOS path, check:
 
 Excel filenames map to display names as follows:
 
-| Filename Pattern | Course Name |
-|-----------------|-------------|
-| `Agent Academy - Special Ops_ YAML Specialist` | Special Ops: YAML Specialist |
-| `Agent Academy - Special Ops_Microsoft Copilot Studio...MCP` | Special Ops: Microsoft Copilot Studio MCP |
+| Filename Pattern                                               | Course Name                                  |
+| -------------------------------------------------------------- | -------------------------------------------- |
+| `Agent Academy - Special Ops_ YAML Specialist`                 | Special Ops: YAML Specialist                 |
+| `Agent Academy - Special Ops_Microsoft Copilot Studio...MCP`   | Special Ops: Microsoft Copilot Studio MCP    |
 | `Agent Academy - Special Ops_ Microsoft Learn Docs MCP Server` | Special Ops: Microsoft Learn Docs MCP Server |
-| `Agent Academy - Special Ops_⚡ Power Platform CLI MCP Server` | Special Ops: Power Platform CLI MCP Server |
-| `Copilot Studio Agent Academy - Operative` | Operative |
-| `Copilot Studio Agent Academy - Recruit` | Recruit |
-| `Cowork Collective_ Badge Check` | Cowork Collective: Badge Check |
-| `Cowork Collective_ Compliance Packet` | Cowork Collective: Compliance Packet |
-| `Cowork Collective_ Out of Office` | Cowork Collective: Out of Office |
+| `Agent Academy - Special Ops_⚡ Power Platform CLI MCP Server` | Special Ops: Power Platform CLI MCP Server   |
+| `Copilot Studio Agent Academy - Operative`                     | Operative                                    |
+| `Copilot Studio Agent Academy - Recruit`                       | Recruit                                      |
+| `Cowork Collective_ Badge Check`                               | Cowork Collective: Badge Check               |
+| `Cowork Collective_ Compliance Packet`                         | Cowork Collective: Compliance Packet         |
+| `Cowork Collective_ Out of Office`                             | Cowork Collective: Out of Office             |
 
 Note: filenames may contain non-breaking spaces (`\xa0`) — normalize these to regular spaces before matching.
 
@@ -252,7 +319,10 @@ To generate a complete report in one go:
 # 1. Extract from Excel
 python3 <skill-path>/scripts/extract_feedback.py "<workspace>/report"
 
-# 2. (Manually fetch GitHub issues via MCP tools and append to _extracted.json → _all_feedback.json)
+# 2. Fetch GitHub issues via MCP tools:
+#    a. Badge submissions: recruit-completed + operative-completed labels (paginate ALL pages)
+#    b. Non-badge issues: all other issues, classified to courses by keyword
+#    c. Add source/is_closed fields, combine with Excel → _all_feedback.json
 
 # 3. Analyze sentiment
 python3 <skill-path>/scripts/analyze_sentiment.py "<workspace>/report"

--- a/.github/skills/agent-academy-report/scripts/build_markdown.py
+++ b/.github/skills/agent-academy-report/scripts/build_markdown.py
@@ -162,9 +162,9 @@ All courses score between **{course_stats[lowest_course]['grade']}/10** and **{c
         else:
             grade_note = "Solid course, but a higher neutral/negative ratio pulls the grade down."
 
-        # Pick quotes proportional to grade (grade 9.1 → 91% positive → ~5 pos out of 5)
-        total_quotes = 5
-        num_pos_q = min(total_quotes, max(1, int(total_quotes * grade / 10 + 0.5)))
+        # Pick quotes proportional to grade (grade 8.0 → 80% positive → 8 pos out of 10)
+        total_quotes = 10
+        num_pos_q = min(total_quotes, max(1, round(total_quotes * grade / 10)))
         num_neg_q = total_quotes - num_pos_q
         # Ensure we don't exceed available quotes
         num_pos_q = min(num_pos_q, len(pos_items))
@@ -260,8 +260,169 @@ All courses score between **{course_stats[lowest_course]['grade']}/10** and **{c
     print(f"  Written: {path}")
 
 
+def _monthly_table(items):
+    """Build a monthly submissions & sentiment table from feedback items."""
+    months = defaultdict(lambda: {'total': 0, 'positive': 0, 'neutral': 0, 'negative': 0})
+    for r in items:
+        m = r.get('month')
+        if not m:
+            continue
+        months[m]['total'] += 1
+        s = r.get('sentiment', 'neutral')
+        if s in months[m]:
+            months[m][s] += 1
+
+    if not months:
+        return ""
+
+    rows = ["| Month | Submissions | 👍 Positive | ➖ Neutral | 👎 Negative | Grade |",
+            "|-------|----------:|------------:|-----------:|------------:|------:|"]
+    for m in sorted(months):
+        d = months[m]
+        t = d['total']
+        grade = round((d['positive'] * 10 + d['neutral'] * 6 + d['negative'] * 2) / t, 1) if t else 0
+        rows.append(
+            f"| {m} | {t} | {d['positive']} ({d['positive']*100//t}%) "
+            f"| {d['neutral']} ({d['neutral']*100//t}%) "
+            f"| {d['negative']} ({d['negative']*100//t}%) "
+            f"| {grade}/10 |"
+        )
+    return '\n'.join(rows) + '\n'
+
+
+def _pick_quotes(items, num=10, max_len=200, grade=None):
+    """Pick a balanced set of representative quotes, optionally grade-based."""
+    pos_items = [r for r in items if r.get('sentiment') == 'positive' and r.get('text')]
+    neg_items = [r for r in items if r.get('sentiment') == 'negative' and r.get('text')]
+
+    if grade is not None:
+        # Grade-based: grade 8/10 → 8 positive, 2 negative
+        num_pos = min(len(pos_items), max(1, round(num * grade / 10)))
+        num_neg = min(len(neg_items), num - num_pos)
+        num_pos = min(len(pos_items), num - num_neg)
+    else:
+        total = len(items) or 1
+        pos_ratio = len(pos_items) / total
+        num_pos = min(len(pos_items), max(1, round(num * pos_ratio)))
+        num_neg = min(len(neg_items), num - num_pos)
+        num_pos = min(len(pos_items), num - num_neg)  # fill remainder
+
+    def clean(text):
+        text = text.replace('\n', ' ').replace('\r', ' ')
+        text = re.sub(r'\*\*[^*]+\*\*\s*', '', text)
+        text = re.sub(r'#+\s+[^\n]+\s*', '', text)
+        text = re.sub(r'- \[.\][^-]*', '', text)
+        text = re.sub(r'^\s*-\s+', '', text)
+        text = re.sub(r'\s+-\s+', '. ', text)
+        text = re.sub(r'&#39;', "'", text)
+        text = re.sub(r'&amp;', '&', text)
+        text = re.sub(r'\s+', ' ', text).strip()
+        if len(text) > max_len:
+            cut = text[:max_len].rfind('.')
+            text = text[:cut + 1] if cut > 80 else text[:max_len].rsplit(' ', 1)[0] + '...'
+        return text
+
+    best_pos = sorted(pos_items, key=lambda r: abs(len(r['text']) - 250))[:num_pos]
+    best_neg = sorted(neg_items, key=lambda r: abs(len(r['text']) - 200))[:num_neg]
+
+    lines = []
+    for q in best_pos:
+        lines.append(f"> 👍 *\"{clean(q['text'])}\"* — {q.get('name') or 'Anonymous'}\n")
+    for q in best_neg:
+        lines.append(f"> 👎 *\"{clean(q['text'])}\"* — {q.get('name') or 'Anonymous'}\n")
+    return '\n'.join(lines)
+
+
+def _course_slug(course):
+    """Generate a filesystem-safe slug for a course name."""
+    return course.lower().replace(' ', '_').replace(':', '').replace('&', 'and')
+
+
+def _build_comparison_table(records):
+    """Build Recruit & Operative comparison: GitHub issues vs Excel forms vs badges."""
+    rows = ["## Recruit & Operative: Submission Pipeline\n"]
+    rows.append("| Metric | Recruit | Operative |")
+    rows.append("|--------|--------:|----------:|")
+
+    for metric, source_filter in [
+        ("GitHub Badge Submissions", lambda r: r.get('source') == 'github_completed'),
+        ("Excel Form Submissions", lambda r: r.get('source') == 'excel'),
+        ("Badges Awarded (Closed Issues)", lambda r: r.get('source') == 'github_completed' and r.get('is_closed')),
+        ("Other GitHub Issues", lambda r: r.get('source') == 'github_issue'),
+    ]:
+        recruit = sum(1 for r in records if r['course'] == 'Recruit' and source_filter(r))
+        operative = sum(1 for r in records if r['course'] == 'Operative' and source_filter(r))
+        if recruit or operative:
+            rows.append(f"| {metric} | {recruit:,} | {operative:,} |")
+
+    # Total row
+    recruit_total = sum(1 for r in records if r['course'] == 'Recruit')
+    operative_total = sum(1 for r in records if r['course'] == 'Operative')
+    rows.append(f"| **Total Records** | **{recruit_total:,}** | **{operative_total:,}** |")
+    rows.append("")
+    return '\n'.join(rows)
+
+
+def _generate_next_steps(course, stats, items):
+    """Generate up to 5 prioritized next steps for a course."""
+    steps = []
+    grade = stats['grade']
+    neg_pct = round(stats['negative'] / stats['total'] * 100) if stats['total'] else 0
+
+    # Identify top negative themes
+    neg_themes = defaultdict(int)
+    for r in items:
+        if r.get('sentiment') == 'negative':
+            for th in r.get('themes', []):
+                neg_themes[th] += 1
+    top_neg = sorted(neg_themes.items(), key=lambda x: -x[1])
+
+    advice_map = {
+        'Setup & Configuration Challenges': 'Simplify setup — provide a pre-configured environment or improved quick-start guide to reduce setup friction.',
+        'Errors & Technical Issues': 'Fix reported bugs — audit the most common failure points and add troubleshooting guidance.',
+        'Improvement Suggestions': 'Act on improvement suggestions — review and prioritize the most-requested changes from participants.',
+        'Clear Instructions & Documentation': 'Improve documentation clarity — review step-by-step guides for completeness and add screenshots where helpful.',
+        'VS Code Integration': 'Improve VS Code experience — ensure extensions and tooling work seamlessly with clear debugging guides.',
+        'MCP & Agent Development Skills': 'Strengthen MCP/agent content — review labs where participants reported MCP-related issues and clarify common pitfalls.',
+        'Valuable Learning Experience': 'Enhance learning depth — some participants felt the content could go deeper. Consider adding advanced optional sections.',
+        'Course Quality & Engagement': 'Refine course structure — address pacing and engagement issues reported by participants.',
+        'Hands-on & Practical Learning': 'Improve hands-on exercises — ensure lab environments are reliable and exercises match real-world scenarios.',
+        'Real-World Applicability': 'Add more real-world examples — participants want to see how skills apply to production scenarios.',
+    }
+
+    # Priority 1–2: Top negative themes (skip themes with fewer than 3 negative mentions)
+    for th, cnt in top_neg[:2]:
+        if cnt >= 3:
+            advice = advice_map.get(th, f'Address "{th}" — {cnt} negative mentions suggest this needs attention.')
+            steps.append(f'{advice} ({cnt} negative mentions)')
+
+    # Priority 3: Grade-based advice
+    if grade < 8.0:
+        steps.append(f'Boost course quality — current grade ({grade}/10) is below the 8.0 target. Focus on reducing the {neg_pct}% negative feedback rate.')
+    elif grade < 8.5:
+        steps.append(f'Target grade improvement — at {grade}/10, small refinements could push this above 8.5.')
+
+    # Priority 4: Leverage top positive theme
+    pos_themes = defaultdict(int)
+    for r in items:
+        if r.get('sentiment') == 'positive':
+            for th in r.get('themes', []):
+                pos_themes[th] += 1
+    top_pos = sorted(pos_themes.items(), key=lambda x: -x[1])
+    if top_pos:
+        steps.append(f'Double down on "{top_pos[0][0]}" — most praised aspect ({top_pos[0][1]} positive mentions). Ensure this remains strong.')
+
+    # Priority 5: Engagement / monitoring
+    if stats['total'] < 50:
+        steps.append(f'Increase feedback volume — only {stats["total"]} responses collected. Consider adding in-course feedback prompts.')
+    else:
+        steps.append('Continue monitoring — maintain the feedback loop and review sentiment trends monthly.')
+
+    return steps[:5]
+
+
 def build_feedback_analysis(data, workspace):
-    """Generate feedback-analysis.md with full detailed analysis."""
+    """Generate feedback-analysis.md — concise per-course analysis (max ~30 pages)."""
     summary = data['summary']
     course_stats = data['course_stats']
     records = data['records']
@@ -273,7 +434,7 @@ def build_feedback_analysis(data, workspace):
     neg = summary['negative']
 
     lines = []
-    lines.append(f"# Agent Academy Feedback Analysis\n")
+    lines.append(f"# Detailed Feedback Analysis\n")
     lines.append(f"**{total} feedback responses** across {len(course_stats)} courses\n")
     lines.append(f"| Sentiment | Count | Percentage |")
     lines.append(f"|-----------|------:|-----------:|")
@@ -301,7 +462,13 @@ def build_feedback_analysis(data, workspace):
 
     lines.append("\n---\n")
 
-    # Per-course sections
+    # Recruit & Operative comparison table (if source data available)
+    has_sources = any(r.get('source') for r in records)
+    if has_sources:
+        lines.append(_build_comparison_table(records))
+        lines.append("---\n")
+
+    # Per-course sections — monthly trend, chart, themes, 10 grade-based quotes, next steps
     for course in COURSE_ORDER:
         if course not in course_stats:
             continue
@@ -317,45 +484,50 @@ def build_feedback_analysis(data, workspace):
             f"· **Grade: {s['grade']}/10**\n"
         )
 
+        # Per-course submission chart
+        slug = _course_slug(course)
+        chart_path = os.path.join(workspace, "charts", f"course_{slug}.png")
+        if os.path.exists(chart_path):
+            lines.append(f"### Submissions Over Time\n")
+            lines.append(f"![{course} Submissions](../charts/course_{slug}.png)\n")
+
+        # Monthly trend table
+        lines.append("### Monthly Trend\n")
+        monthly = _monthly_table(items)
+        if monthly:
+            lines.append(monthly)
+        else:
+            lines.append("*No monthly data available.*\n")
+
         # Themes
         if s.get('themes'):
-            lines.append("### Common Themes\n")
-            pos_themes = [(th, cnt) for th, cnt in s['themes'].items()
-                          if any(r['sentiment'] == 'positive' and th in r.get('themes', []) for r in items)]
-            neg_themes = [(th, cnt) for th, cnt in s['themes'].items()
-                          if any(r['sentiment'] == 'negative' and th in r.get('themes', []) for r in items)]
+            lines.append("### Top Themes\n")
+            top_themes = sorted(s['themes'].items(), key=lambda x: -x[1])[:5]
+            for th, cnt in top_themes:
+                neg_count = sum(1 for r in items if r['sentiment'] == 'negative' and th in r.get('themes', []))
+                pos_count = sum(1 for r in items if r['sentiment'] == 'positive' and th in r.get('themes', []))
+                if neg_count > pos_count:
+                    lines.append(f"- 👎 {th} ({cnt} mentions)")
+                else:
+                    lines.append(f"- 👍 {th} ({cnt} mentions)")
+            lines.append("")
 
-            if pos_themes:
-                lines.append("**👍 Positive themes:**\n")
-                for th, cnt in sorted(s['themes'].items(), key=lambda x: -x[1]):
-                    lines.append(f"- {th} ({cnt} mentions)")
-            if neg_themes:
-                lines.append("\n**👎 Negative themes:**\n")
-                for th, _ in neg_themes:
-                    neg_count = sum(1 for r in items if r['sentiment'] == 'negative' and th in r.get('themes', []))
-                    lines.append(f"- {th} ({neg_count} mentions)")
+        # Representative quotes (10 per course, grade-based balance)
+        lines.append("### Representative Quotes\n")
+        quotes = _pick_quotes(items, num=10, grade=s['grade'])
+        if quotes:
+            lines.append(quotes)
+        else:
+            lines.append("*No feedback text available.*\n")
 
-        # Feedback items sorted: positive → neutral → negative
-        lines.append("\n### Feedback\n")
-        sort_order = {'positive': 0, 'neutral': 1, 'negative': 2}
-        sorted_items = sorted(items, key=lambda r: sort_order.get(r.get('sentiment', 'neutral'), 1))
+        # Next steps (up to 5 prioritized recommendations)
+        lines.append("### Next Steps\n")
+        next_steps = _generate_next_steps(course, s, items)
+        for i, step in enumerate(next_steps, 1):
+            lines.append(f"{i}. **{step.split(' — ')[0]}** — {' — '.join(step.split(' — ')[1:])}" if ' — ' in step else f"{i}. {step}")
+        lines.append("")
 
-        for i, r in enumerate(sorted_items):
-            text = r.get('text', '')
-            if not text:
-                continue
-
-            emoji = {'positive': '👍', 'neutral': '➖', 'negative': '👎'}.get(r.get('sentiment', 'neutral'), '➖')
-            name = r.get('name', 'Anonymous') or 'Anonymous'
-
-            # Format as blockquote (prefix every line with >)
-            quoted = '\n'.join(f'> {line}' for line in f'{emoji} "{text}" — {name}'.split('\n'))
-            lines.append(quoted)
-
-            if i < len(sorted_items) - 1:
-                lines.append("\n---\n")
-
-        lines.append("\n---\n")
+        lines.append("---\n")
 
     md_dir = os.path.join(workspace, "markdown")
     os.makedirs(md_dir, exist_ok=True)
@@ -366,7 +538,7 @@ def build_feedback_analysis(data, workspace):
 
 
 def build_positive_feedback(data, workspace):
-    """Generate feedback.md with curated positive-only feedback."""
+    """Generate feedback.md with curated positive-only feedback (max 5 per course)."""
     records = data['records']
     feedback = [r for r in records if r['type'] == 'feedback' and r.get('sentiment') == 'positive']
 
@@ -378,8 +550,19 @@ def build_positive_feedback(data, workspace):
             continue
         filtered.append(r)
 
+    # Group by course and pick best 5 per course (closest to 250 chars)
+    by_course = defaultdict(list)
+    for r in filtered:
+        by_course[r.get('course', 'Unknown')].append(r)
+
+    selected = []
+    for course in COURSE_ORDER:
+        items = by_course.get(course, [])
+        best = sorted(items, key=lambda r: abs(len(r.get('text', '')) - 250))[:5]
+        selected.extend(best)
+
     lines = ["# Agent Academy Feedback\n"]
-    for i, r in enumerate(filtered):
+    for i, r in enumerate(selected):
         text = r.get('text', '')
         name = r.get('name', 'Anonymous') or 'Anonymous'
         course = r.get('course', '')
@@ -387,7 +570,7 @@ def build_positive_feedback(data, workspace):
         quoted = '\n'.join(f'> {line}' for line in f'👍 "{text}" — {name} ({course})'.split('\n'))
         lines.append(quoted)
 
-        if i < len(filtered) - 1:
+        if i < len(selected) - 1:
             lines.append("\n---\n")
 
     md_dir = os.path.join(workspace, "markdown")
@@ -395,7 +578,7 @@ def build_positive_feedback(data, workspace):
     path = os.path.join(md_dir, "feedback.md")
     with open(path, 'w') as f:
         f.write('\n'.join(lines))
-    print(f"  Written: {path} ({len(filtered)} items)")
+    print(f"  Written: {path} ({len(selected)} items)")
 
 
 def main():

--- a/.github/skills/agent-academy-report/scripts/build_markdown.py
+++ b/.github/skills/agent-academy-report/scripts/build_markdown.py
@@ -23,6 +23,23 @@ COURSE_ORDER = [
     "Cowork Collective: Badge Check", "Cowork Collective: Compliance Packet", "Cowork Collective: Out of Office",
 ]
 
+# Sections group courses into the 4 main report sections
+SECTIONS = [
+    ("Recruit", ["Recruit"]),
+    ("Operative", ["Operative"]),
+    ("Special Ops", [
+        "Special Ops: YAML Specialist",
+        "Special Ops: Microsoft Copilot Studio MCP",
+        "Special Ops: Microsoft Learn Docs MCP Server",
+        "Special Ops: Power Platform CLI MCP Server",
+    ]),
+    ("Cowork Collective", [
+        "Cowork Collective: Badge Check",
+        "Cowork Collective: Compliance Packet",
+        "Cowork Collective: Out of Office",
+    ]),
+]
+
 ERROR_PATTERNS = [
     r'\berror\b', r'\bfail\b', r'\bcrash\b', r'\bbroke\b', r'\bbug\b',
     r'\bstuck\b', r'\bdidn.t work\b', r'\bnot work\b',
@@ -130,46 +147,50 @@ All courses score between **{course_stats[lowest_course]['grade']}/10** and **{c
 
 """
 
-    # --- Per-course spotlight section ---
+    # --- Per-section spotlight ---
     feedback = [r for r in records if r['type'] == 'feedback']
 
-    md += "## Course Spotlights\n\n"
+    def _grade_note(grade):
+        if grade >= 9.0:
+            return "Exceptional satisfaction — one of the top-rated courses."
+        elif grade >= 8.5:
+            return "Strong satisfaction with consistently positive feedback."
+        elif grade >= 8.0:
+            return "Good satisfaction, though some participants encountered challenges."
+        return "Solid course, but a higher neutral/negative ratio pulls the grade down."
 
-    for course in COURSE_ORDER:
-        if course not in course_stats:
-            continue
-        s = course_stats[course]
+    def _clean_quote(text, max_len=200):
+        text = text.replace('\n', ' ').replace('\r', ' ')
+        text = re.sub(r'\*\*[^*]+\*\*\s*', '', text)
+        text = re.sub(r'#+\s+[^\n]+\s*', '', text)
+        text = re.sub(r'- \[.\][^-]*', '', text)
+        text = re.sub(r'^\s*-\s+', '', text)
+        text = re.sub(r'\s+-\s+', '. ', text)
+        text = re.sub(r'&#39;', "'", text)
+        text = re.sub(r'&amp;', '&', text)
+        text = re.sub(r'\s+', ' ', text).strip()
+        if len(text) > max_len:
+            cut = text[:max_len].rfind('.')
+            text = text[:cut + 1] if cut > 100 else text[:max_len].rsplit(' ', 1)[0] + '...'
+        return text
+
+    def _spotlight_course(course, s, items):
+        """Build spotlight block for a single course/mission."""
         t = s['total']
         pos_pct_c = round(s['positive'] / t * 100)
         neg_pct_c = round(s['negative'] / t * 100)
         grade = s['grade']
-
-        items = [r for r in feedback if r['course'] == course]
         pos_items = [r for r in items if r.get('sentiment') == 'positive']
         neg_items = [r for r in items if r.get('sentiment') == 'negative']
 
-        # Top themes
         themes = s.get('themes', {})
         top_themes = sorted(themes.items(), key=lambda x: -x[1])[:3]
 
-        # Grade explanation
-        if grade >= 9.0:
-            grade_note = "Exceptional satisfaction — one of the top-rated courses."
-        elif grade >= 8.5:
-            grade_note = "Strong satisfaction with consistently positive feedback."
-        elif grade >= 8.0:
-            grade_note = "Good satisfaction, though some participants encountered challenges."
-        else:
-            grade_note = "Solid course, but a higher neutral/negative ratio pulls the grade down."
-
-        # Pick quotes proportional to grade (grade 8.0 → 80% positive → 8 pos out of 10)
         total_quotes = 10
         num_pos_q = min(total_quotes, max(1, round(total_quotes * grade / 10)))
         num_neg_q = total_quotes - num_pos_q
-        # Ensure we don't exceed available quotes
         num_pos_q = min(num_pos_q, len(pos_items))
         num_neg_q = min(num_neg_q, len(neg_items))
-        # Fill remaining slots from the other side
         if num_pos_q + num_neg_q < total_quotes:
             extra = total_quotes - num_pos_q - num_neg_q
             if len(pos_items) > num_pos_q:
@@ -181,64 +202,80 @@ All courses score between **{course_stats[lowest_course]['grade']}/10** and **{c
         best_pos = sorted(pos_items, key=lambda r: abs(len(r.get('text', '')) - 250))[:num_pos_q]
         best_neg = sorted(neg_items, key=lambda r: abs(len(r.get('text', '')) - 200))[:num_neg_q]
 
-        md += f"### {course}\n\n"
-        md += f"**{t} responses** · Grade: **{grade}/10** · "
-        md += f"👍 {pos_pct_c}% positive · 👎 {neg_pct_c}% negative\n\n"
-        md += f"{grade_note}\n\n"
+        out = ""
+        out += f"**{t} responses** · Grade: **{grade}/10** · "
+        out += f"👍 {pos_pct_c}% positive · 👎 {neg_pct_c}% negative\n\n"
+        out += f"{_grade_note(grade)}\n\n"
 
         if top_themes:
-            md += "**Top themes:** "
-            md += ", ".join(f"{th} ({cnt})" for th, cnt in top_themes)
-            md += "\n\n"
+            out += "**Top themes:** " + ", ".join(f"{th} ({cnt})" for th, cnt in top_themes) + "\n\n"
 
-        # Highlight
         if pos_pct_c >= 85:
-            md += f"**Standout:** {pos_pct_c}% of respondents were positive — learners particularly valued "
-            if top_themes:
-                md += f"the {top_themes[0][0].lower()}.\n\n"
-            else:
-                md += "the course content.\n\n"
+            out += f"**Standout:** {pos_pct_c}% of respondents were positive — learners particularly valued "
+            out += (f"the {top_themes[0][0].lower()}.\n\n" if top_themes else "the course content.\n\n")
         elif neg_pct_c >= 15:
-            md += f"**Watch area:** {neg_pct_c}% reported negative experiences, "
-            neg_themes = [(th, cnt) for th, cnt in themes.items()
-                         if any(r['sentiment'] == 'negative' and th in r.get('themes', []) for r in neg_items)]
-            if neg_themes:
-                top_neg_theme = sorted(neg_themes, key=lambda x: -x[1])[0][0]
-                md += f"primarily around {top_neg_theme.lower()}.\n\n"
+            out += f"**Watch area:** {neg_pct_c}% reported negative experiences, "
+            neg_th = [(th, cnt) for th, cnt in themes.items()
+                      if any(r['sentiment'] == 'negative' and th in r.get('themes', []) for r in neg_items)]
+            if neg_th:
+                out += f"primarily around {sorted(neg_th, key=lambda x: -x[1])[0][0].lower()}.\n\n"
             else:
-                md += "primarily around technical challenges.\n\n"
-
-        def clean_quote(text, max_len=200):
-            """Clean up a quote for display."""
-            text = text.replace('\n', ' ').replace('\r', ' ')
-            text = re.sub(r'\*\*[^*]+\*\*\s*', '', text)  # Remove bold headers
-            text = re.sub(r'#+\s+[^\n]+\s*', '', text)  # Remove markdown headers
-            text = re.sub(r'- \[.\][^-]*', '', text)  # Remove checkbox lines
-            text = re.sub(r'^\s*-\s+', '', text)  # Remove leading list dash
-            text = re.sub(r'\s+-\s+', '. ', text)  # Convert list dashes to periods
-            text = re.sub(r'&#39;', "'", text)  # Fix HTML entities
-            text = re.sub(r'&amp;', '&', text)
-            text = re.sub(r'\s+', ' ', text).strip()
-            if len(text) > max_len:
-                # Cut at sentence boundary
-                cut = text[:max_len].rfind('.')
-                if cut > 100:
-                    text = text[:cut + 1]
-                else:
-                    text = text[:max_len].rsplit(' ', 1)[0] + '...'
-            return text
+                out += "primarily around technical challenges.\n\n"
 
         for q in best_pos:
-            quote = clean_quote(q.get('text', ''))
-            name = q.get('name', 'Anonymous')
-            md += f"> 👍 *\"{quote}\"* — {name}\n\n"
-
+            out += f"> 👍 *\"{_clean_quote(q.get('text', ''))}\"* — {q.get('name', 'Anonymous')}\n\n"
         for q in best_neg:
-            quote = clean_quote(q.get('text', ''), 180)
-            name = q.get('name', 'Anonymous')
-            md += f"> 👎 *\"{quote}\"* — {name}\n\n"
+            out += f"> 👎 *\"{_clean_quote(q.get('text', ''), 180)}\"* — {q.get('name', 'Anonymous')}\n\n"
+        return out
 
-        md += "---\n\n"
+    for section_name, section_courses in SECTIONS:
+        active = [c for c in section_courses if c in course_stats]
+        if not active:
+            continue
+
+        md += f"## {section_name}\n\n"
+
+        # For multi-mission sections, add a section-level summary first
+        if len(active) > 1:
+            agg = _aggregate_stats(active, course_stats, feedback)
+            if agg:
+                t = agg['total']
+                pos_pct_s = round(agg['positive'] / t * 100)
+                neg_pct_s = round(agg['negative'] / t * 100)
+                md += f"**{t} total responses** across {len(active)} missions · "
+                md += f"Combined grade: **{agg['grade']}/10** · "
+                md += f"👍 {pos_pct_s}% positive · 👎 {neg_pct_s}% negative\n\n"
+
+                top_sec_themes = sorted(agg['themes'].items(), key=lambda x: -x[1])[:3]
+                if top_sec_themes:
+                    md += "**Cross-mission themes:** " + ", ".join(f"{th} ({cnt})" for th, cnt in top_sec_themes) + "\n\n"
+
+                # Section-level next steps
+                sec_steps = _generate_next_steps(section_name, agg, agg['items'])
+                if sec_steps:
+                    md += f"**{section_name} Next Steps:**\n\n"
+                    for i, step in enumerate(sec_steps, 1):
+                        md += (f"{i}. **{step.split(' — ')[0]}** — {' — '.join(step.split(' — ')[1:])}\n" if ' — ' in step else f"{i}. {step}\n")
+                    md += "\n"
+
+                md += "---\n\n"
+
+            # Per-mission spotlights
+            for course in active:
+                s = course_stats[course]
+                items = [r for r in feedback if r['course'] == course]
+                # Use short mission name (strip section prefix)
+                display = course.split(': ', 1)[1] if ': ' in course else course
+                md += f"### {display}\n\n"
+                md += _spotlight_course(course, s, items)
+                md += "---\n\n"
+        else:
+            # Single-course section (Recruit, Operative)
+            course = active[0]
+            s = course_stats[course]
+            items = [r for r in feedback if r['course'] == course]
+            md += _spotlight_course(course, s, items)
+            md += "---\n\n"
 
     md += """## Recommendations
 
@@ -338,6 +375,29 @@ def _pick_quotes(items, num=10, max_len=200, grade=None):
 def _course_slug(course):
     """Generate a filesystem-safe slug for a course name."""
     return course.lower().replace(' ', '_').replace(':', '').replace('&', 'and')
+
+
+def _aggregate_stats(courses, course_stats, feedback):
+    """Compute aggregate stats for a group of courses."""
+    items = [r for r in feedback if r['course'] in courses]
+    if not items:
+        return None
+    total = len(items)
+    pos = sum(1 for r in items if r.get('sentiment') == 'positive')
+    neu = sum(1 for r in items if r.get('sentiment') == 'neutral')
+    neg = sum(1 for r in items if r.get('sentiment') == 'negative')
+    scores = {'positive': 10, 'neutral': 6, 'negative': 2}
+    grade = round(sum(scores.get(r.get('sentiment', 'neutral'), 6) for r in items) / total, 1)
+    # Merge themes
+    theme_counts = defaultdict(int)
+    for c in courses:
+        if c in course_stats:
+            for th, cnt in course_stats[c].get('themes', {}).items():
+                theme_counts[th] += cnt
+    return {
+        'total': total, 'positive': pos, 'neutral': neu, 'negative': neg,
+        'grade': grade, 'themes': dict(theme_counts), 'items': items,
+    }
 
 
 def _build_comparison_table(records):
@@ -486,66 +546,138 @@ def build_feedback_analysis(data, workspace):
         lines.append(_build_comparison_table(records))
         lines.append("---\n")
 
-    # Per-course sections — monthly trend, chart, themes, 10 grade-based quotes, next steps
-    for course in COURSE_ORDER:
-        if course not in course_stats:
-            continue
+    def _course_block(course, heading_level="##"):
+        """Generate a full analysis block for one course."""
         s = course_stats[course]
         t = s['total']
         items = [r for r in feedback if r['course'] == course]
+        block = []
 
-        lines.append(f"## {course}\n")
-        lines.append(
+        display = course.split(': ', 1)[1] if ': ' in course and heading_level == "###" else course
+        block.append(f"{heading_level} {display}\n")
+        block.append(
             f"**{t} responses** — 👍 {s['positive']} ({s['positive']*100//t}%) "
             f"· ➖ {s['neutral']} ({s['neutral']*100//t}%) "
             f"· 👎 {s['negative']} ({s['negative']*100//t}%) "
             f"· **Grade: {s['grade']}/10**\n"
         )
 
-        # Per-course submission chart
         slug = _course_slug(course)
         chart_path = os.path.join(workspace, "charts", f"course_{slug}.png")
         if os.path.exists(chart_path):
-            lines.append(f"### Submissions Over Time\n")
-            lines.append(f"![{course} Submissions](../charts/course_{slug}.png)\n")
+            block.append(f"{'#' * (len(heading_level) + 1)} Submissions Over Time\n")
+            block.append(f"![{course} Submissions](../charts/course_{slug}.png)\n")
 
-        # Monthly trend table
-        lines.append("### Monthly Trend\n")
+        block.append(f"{'#' * (len(heading_level) + 1)} Monthly Trend\n")
         monthly = _monthly_table(items)
-        if monthly:
-            lines.append(monthly)
-        else:
-            lines.append("*No monthly data available.*\n")
+        block.append(monthly if monthly else "*No monthly data available.*\n")
 
-        # Themes
         if s.get('themes'):
-            lines.append("### Top Themes\n")
+            block.append(f"{'#' * (len(heading_level) + 1)} Top Themes\n")
             top_themes = sorted(s['themes'].items(), key=lambda x: -x[1])[:5]
             for th, cnt in top_themes:
                 neg_count = sum(1 for r in items if r['sentiment'] == 'negative' and th in r.get('themes', []))
                 pos_count = sum(1 for r in items if r['sentiment'] == 'positive' and th in r.get('themes', []))
-                if neg_count > pos_count:
-                    lines.append(f"- 👎 {th} ({cnt} mentions)")
-                else:
-                    lines.append(f"- 👍 {th} ({cnt} mentions)")
-            lines.append("")
+                block.append(f"- {'👎' if neg_count > pos_count else '👍'} {th} ({cnt} mentions)")
+            block.append("")
 
-        # Representative quotes (10 per course, grade-based balance)
-        lines.append("### Representative Quotes\n")
+        block.append(f"{'#' * (len(heading_level) + 1)} Representative Quotes\n")
         quotes = _pick_quotes(items, num=10, grade=s['grade'])
-        if quotes:
-            lines.append(quotes)
-        else:
-            lines.append("*No feedback text available.*\n")
+        block.append(quotes if quotes else "*No feedback text available.*\n")
 
-        # Next steps (up to 5 prioritized recommendations)
-        lines.append("### Next Steps\n")
+        block.append(f"{'#' * (len(heading_level) + 1)} Next Steps\n")
         next_steps = _generate_next_steps(course, s, items)
         for i, step in enumerate(next_steps, 1):
-            lines.append(f"{i}. **{step.split(' — ')[0]}** — {' — '.join(step.split(' — ')[1:])}" if ' — ' in step else f"{i}. {step}")
-        lines.append("")
+            block.append(f"{i}. **{step.split(' — ')[0]}** — {' — '.join(step.split(' — ')[1:])}" if ' — ' in step else f"{i}. {step}")
+        block.append("")
+        block.append("---\n")
+        return block
 
-        lines.append("---\n")
+    # 4 main sections
+    for section_name, section_courses in SECTIONS:
+        active = [c for c in section_courses if c in course_stats]
+        if not active:
+            continue
+
+        lines.append(f"## {section_name}\n")
+
+        if len(active) > 1:
+            # Multi-mission section: section-level summary first
+            agg = _aggregate_stats(active, course_stats, feedback)
+            if agg:
+                t = agg['total']
+                pos_pct = round(agg['positive'] / t * 100)
+                neg_pct = round(agg['negative'] / t * 100)
+                lines.append(
+                    f"**{t} total responses** across {len(active)} missions · "
+                    f"Combined grade: **{agg['grade']}/10** · "
+                    f"👍 {pos_pct}% positive · 👎 {neg_pct}% negative\n"
+                )
+
+                top_themes = sorted(agg['themes'].items(), key=lambda x: -x[1])[:5]
+                if top_themes:
+                    lines.append(f"### Cross-Mission Themes\n")
+                    for th, cnt in top_themes:
+                        neg_c = sum(1 for r in agg['items'] if r['sentiment'] == 'negative' and th in r.get('themes', []))
+                        pos_c = sum(1 for r in agg['items'] if r['sentiment'] == 'positive' and th in r.get('themes', []))
+                        lines.append(f"- {'👎' if neg_c > pos_c else '👍'} {th} ({cnt} mentions)")
+                    lines.append("")
+
+                sec_steps = _generate_next_steps(section_name, agg, agg['items'])
+                if sec_steps:
+                    lines.append(f"### {section_name} Recommendations\n")
+                    for i, step in enumerate(sec_steps, 1):
+                        lines.append(f"{i}. **{step.split(' — ')[0]}** — {' — '.join(step.split(' — ')[1:])}" if ' — ' in step else f"{i}. {step}")
+                    lines.append("")
+
+                lines.append("---\n")
+
+            # Per-mission blocks (use h3 with short names)
+            for course in active:
+                lines.extend(_course_block(course, "###"))
+        else:
+            # Single-course section (Recruit, Operative) — content directly under h2
+            course = active[0]
+            s = course_stats[course]
+            t = s['total']
+            items = [r for r in feedback if r['course'] == course]
+
+            lines.append(
+                f"**{t} responses** — 👍 {s['positive']} ({s['positive']*100//t}%) "
+                f"· ➖ {s['neutral']} ({s['neutral']*100//t}%) "
+                f"· 👎 {s['negative']} ({s['negative']*100//t}%) "
+                f"· **Grade: {s['grade']}/10**\n"
+            )
+
+            slug = _course_slug(course)
+            chart_path = os.path.join(workspace, "charts", f"course_{slug}.png")
+            if os.path.exists(chart_path):
+                lines.append(f"### Submissions Over Time\n")
+                lines.append(f"![{course} Submissions](../charts/course_{slug}.png)\n")
+
+            lines.append("### Monthly Trend\n")
+            monthly = _monthly_table(items)
+            lines.append(monthly if monthly else "*No monthly data available.*\n")
+
+            if s.get('themes'):
+                lines.append("### Top Themes\n")
+                top_themes = sorted(s['themes'].items(), key=lambda x: -x[1])[:5]
+                for th, cnt in top_themes:
+                    neg_count = sum(1 for r in items if r['sentiment'] == 'negative' and th in r.get('themes', []))
+                    pos_count = sum(1 for r in items if r['sentiment'] == 'positive' and th in r.get('themes', []))
+                    lines.append(f"- {'👎' if neg_count > pos_count else '👍'} {th} ({cnt} mentions)")
+                lines.append("")
+
+            lines.append("### Representative Quotes\n")
+            quotes = _pick_quotes(items, num=10, grade=s['grade'])
+            lines.append(quotes if quotes else "*No feedback text available.*\n")
+
+            lines.append("### Next Steps\n")
+            next_steps = _generate_next_steps(course, s, items)
+            for i, step in enumerate(next_steps, 1):
+                lines.append(f"{i}. **{step.split(' — ')[0]}** — {' — '.join(step.split(' — ')[1:])}" if ' — ' in step else f"{i}. {step}")
+            lines.append("")
+            lines.append("---\n")
 
     md_dir = os.path.join(workspace, "markdown")
     os.makedirs(md_dir, exist_ok=True)

--- a/.github/skills/agent-academy-report/scripts/build_markdown.py
+++ b/.github/skills/agent-academy-report/scripts/build_markdown.py
@@ -35,7 +35,7 @@ def build_management_summary(data, workspace):
     course_stats = data['course_stats']
     records = data['records']
 
-    total_completions = len(records)
+    total_completions = sum(1 for r in records if r.get('source') != 'github_issue')
     total_feedback = summary['total_feedback']
     overall_grade = summary['overall_grade']
     pos_pct = round(summary['positive'] / total_feedback * 100)
@@ -261,9 +261,11 @@ All courses score between **{course_stats[lowest_course]['grade']}/10** and **{c
 
 
 def _monthly_table(items):
-    """Build a monthly submissions & sentiment table from feedback items."""
+    """Build a monthly submissions & sentiment table from feedback items (excludes non-badge GitHub issues)."""
     months = defaultdict(lambda: {'total': 0, 'positive': 0, 'neutral': 0, 'negative': 0})
     for r in items:
+        if r.get('source') == 'github_issue':
+            continue
         m = r.get('month')
         if not m:
             continue

--- a/.github/skills/agent-academy-report/scripts/build_markdown.py
+++ b/.github/skills/agent-academy-report/scripts/build_markdown.py
@@ -248,12 +248,13 @@ All courses score between **{course_stats[lowest_course]['grade']}/10** and **{c
 
                 top_sec_themes = sorted(agg['themes'].items(), key=lambda x: -x[1])[:3]
                 if top_sec_themes:
-                    md += "**Cross-mission themes:** " + ", ".join(f"{th} ({cnt})" for th, cnt in top_sec_themes) + "\n\n"
+                    md += "### Cross-Mission Themes\n\n"
+                    md += ", ".join(f"{th} ({cnt})" for th, cnt in top_sec_themes) + "\n\n"
 
                 # Section-level next steps
                 sec_steps = _generate_next_steps(section_name, agg, agg['items'])
                 if sec_steps:
-                    md += f"**{section_name} Next Steps:**\n\n"
+                    md += f"### {section_name} Next Steps\n\n"
                     for i, step in enumerate(sec_steps, 1):
                         md += (f"{i}. **{step.split(' — ')[0]}** — {' — '.join(step.split(' — ')[1:])}\n" if ' — ' in step else f"{i}. {step}\n")
                     md += "\n"
@@ -277,12 +278,12 @@ All courses score between **{course_stats[lowest_course]['grade']}/10** and **{c
             md += _spotlight_course(course, s, items)
             md += "---\n\n"
 
-    md += """## Recommendations
+    md += f"""## Recommendations
 
-1. **Address Setup Challenges** — The most common negative theme across technical courses is setup difficulty. Consider providing pre-configured environments or improved setup documentation.
-2. **Expand Cowork Collective** — These courses have the highest satisfaction; consider adding more missions in this format.
-3. **Scale Special Ops** — Technical courses show strong engagement; the slightly lower grades present an opportunity for targeted improvements.
-4. **Continue Monitoring** — The feedback pipeline provides ongoing insights; consider monthly reviews to track sentiment trends.
+- **Address Setup Challenges** — The most common negative theme across technical courses is setup difficulty. Consider providing pre-configured environments or improved setup documentation.
+- **Expand Cowork Collective** — These courses have the highest satisfaction; consider adding more missions in this format.
+- **Scale Special Ops** — Technical courses show strong engagement; the slightly lower grades present an opportunity for targeted improvements.
+- **Continue Monitoring** — The feedback pipeline provides ongoing insights; consider monthly reviews to track sentiment trends.
 
 ---
 

--- a/.github/skills/agent-academy-report/scripts/build_markdown.py
+++ b/.github/skills/agent-academy-report/scripts/build_markdown.py
@@ -341,27 +341,43 @@ def _course_slug(course):
 
 
 def _build_comparison_table(records):
-    """Build Recruit & Operative comparison: GitHub issues vs Excel forms vs badges."""
+    """Build Recruit & Operative funnel-style comparison."""
     rows = ["## Recruit & Operative: Submission Pipeline\n"]
-    rows.append("| Metric | Recruit | Operative |")
-    rows.append("|--------|--------:|----------:|")
+    rows.append("| Stage | Recruit | Operative |")
+    rows.append("|-------|--------:|----------:|")
 
-    for metric, source_filter in [
-        ("GitHub Badge Submissions", lambda r: r.get('source') == 'github_completed'),
-        ("Excel Form Submissions", lambda r: r.get('source') == 'excel'),
-        ("Badges Awarded (Closed Issues)", lambda r: r.get('source') == 'github_completed' and r.get('is_closed')),
-        ("Other GitHub Issues", lambda r: r.get('source') == 'github_issue'),
-    ]:
-        recruit = sum(1 for r in records if r['course'] == 'Recruit' and source_filter(r))
-        operative = sum(1 for r in records if r['course'] == 'Operative' and source_filter(r))
-        if recruit or operative:
-            rows.append(f"| {metric} | {recruit:,} | {operative:,} |")
+    # Gather per-course numbers
+    data = {}
+    for course in ['Recruit', 'Operative']:
+        gh = sum(1 for r in records if r['course'] == course and r.get('source') == 'github_completed')
+        excel = sum(1 for r in records if r['course'] == course and r.get('source') == 'excel')
+        badges = sum(1 for r in records if r['course'] == course and r.get('source') == 'github_completed' and r.get('is_closed'))
+        issues = sum(1 for r in records if r['course'] == course and r.get('source') == 'github_issue')
+        data[course] = {'gh': gh, 'excel': excel, 'badges': badges, 'issues': issues}
 
-    # Total row
-    recruit_total = sum(1 for r in records if r['course'] == 'Recruit')
-    operative_total = sum(1 for r in records if r['course'] == 'Operative')
-    rows.append(f"| **Total Records** | **{recruit_total:,}** | **{operative_total:,}** |")
+    r, o = data['Recruit'], data['Operative']
+
+    # Funnel rows with indentation showing flow
+    rows.append(f"| **1. GitHub Badge Submissions** | **{r['gh']:,}** | **{o['gh']:,}** |")
+    rows.append(
+        f"| &nbsp;&nbsp;&nbsp;↳ Badges Awarded ✅ | {r['badges']:,} ({r['badges']*100//r['gh']}%) "
+        f"| {o['badges']:,} ({o['badges']*100//o['gh']}%) |"
+    )
+    r_open, o_open = r['gh'] - r['badges'], o['gh'] - o['badges']
+    rows.append(
+        f"| &nbsp;&nbsp;&nbsp;↳ Pending Review ⏳ | {r_open:,} ({r_open*100//r['gh']}%) "
+        f"| {o_open:,} ({o_open*100//o['gh']}%) |"
+    )
+    rows.append(f"| **2. Excel Survey Responses** | **{r['excel']:,}** | **{o['excel']:,}** |")
+    rows.append(f"| **3. Other GitHub Issues** | **{r['issues']:,}** | **{o['issues']:,}** |")
+
     rows.append("")
+    rows.append(
+        f"> **Note:** GitHub badge submissions and Excel survey responses are **independent channels**. "
+        f"Learners open a GitHub issue to claim their badge, and separately fill out a Forms survey. "
+        f"Not all badge recipients complete the survey, which is why Recruit has more badges awarded "
+        f"({r['badges']:,}) than Excel submissions ({r['excel']:,}).\n"
+    )
     return '\n'.join(rows)
 
 

--- a/.github/skills/agent-academy-report/scripts/export_pdf.py
+++ b/.github/skills/agent-academy-report/scripts/export_pdf.py
@@ -66,13 +66,24 @@ def download_badges(badges_dir):
 
 def embed_md_images(html, base_dir):
     """Replace markdown image refs with base64-embedded images."""
+    # Charts that should be rendered at a smaller size (not full width)
+    SMALL_CHARTS = ['sentiment_pie']
+    MEDIUM_CHARTS = ['course_']
+
     def replacer(match):
         alt = match.group(1)
         src = match.group(2)
         full = os.path.join(base_dir, src) if not os.path.isabs(src) else src
         if os.path.exists(full):
             b64 = img_to_b64(full)
-            return f'<img src="data:image/png;base64,{b64}" alt="{alt}" style="max-width:100%; margin:15px 0;">'
+            fname = os.path.basename(src)
+            if any(s in fname for s in SMALL_CHARTS):
+                style = 'max-width:45%; margin:15px auto;'
+            elif any(s in fname for s in MEDIUM_CHARTS):
+                style = 'max-width:85%; margin:15px auto;'
+            else:
+                style = 'max-width:100%; margin:15px 0;'
+            return f'<img src="data:image/png;base64,{b64}" alt="{alt}" style="{style}">'
         return match.group(0)
     return re.sub(r'!\[([^\]]*)\]\(([^)]+)\)', replacer, html)
 
@@ -371,6 +382,8 @@ h2 {{
     color: var(--brand-blue); margin-top: 35px; font-size: 22px;
     border-bottom: 1px solid #e2e8f0; padding-bottom: 6px;
 }}
+/* First h2 in management summary should NOT page-break (it's right after h1) */
+.content > h2:first-of-type {{ }}
 h3 {{ color: #1e293b; font-size: 17px; margin-top: 25px; font-weight: 600; }}
 h4 {{ color: #475569; font-size: 15px; font-weight: 600; }}
 table {{ border-collapse: collapse; margin: 15px 0; width: 100%; font-size: 13px; }}
@@ -395,7 +408,9 @@ a {{ color: var(--brand-blue); text-decoration: none; }}
 @media print {{
     .cover-page {{ height: 100vh; }}
     .content {{ padding: 30px 40px; }}
-    img {{ max-width: 100% !important; page-break-inside: avoid; break-inside: avoid; }}
+    img {{ page-break-inside: avoid; break-inside: avoid; }}
+    h2 {{ page-break-before: always; break-before: page; margin-top: 0; padding-top: 10px; }}
+    .content > h2:first-of-type {{ page-break-before: avoid; break-before: avoid; }}
     h2, h3, h4 {{ page-break-after: avoid; break-after: avoid; }}
     blockquote {{ page-break-inside: avoid; break-inside: avoid; }}
     table {{ page-break-inside: avoid; break-inside: avoid; }}
@@ -458,7 +473,7 @@ def main():
     print("Building combined HTML...")
     html = build_html(workspace, title)
 
-    html_path = os.path.join(workspace, "_report.html")
+    html_path = os.path.abspath(os.path.join(workspace, "_report.html"))
     with open(html_path, 'w') as f:
         f.write(html)
 

--- a/.github/skills/agent-academy-report/scripts/extract_feedback.py
+++ b/.github/skills/agent-academy-report/scripts/extract_feedback.py
@@ -78,6 +78,7 @@ def extract_file(filepath):
                     'text': None,
                     'name': None,
                     'type': 'completion',
+                    'source': 'excel',
                 })
         wb.close()
         return records
@@ -103,6 +104,7 @@ def extract_file(filepath):
                 'text': text.strip(),
                 'name': name,
                 'type': 'feedback',
+                'source': 'excel',
             })
 
     wb.close()

--- a/.github/skills/agent-academy-report/scripts/generate_charts.py
+++ b/.github/skills/agent-academy-report/scripts/generate_charts.py
@@ -403,16 +403,18 @@ def main():
     records = data['records']
     course_stats = data['course_stats']
     feedback = [r for r in records if r['type'] == 'feedback']
+    # Submissions = actual course completions (Excel forms + GitHub badge submissions), not bug reports
+    submissions = [r for r in records if r.get('source') != 'github_issue']
 
     setup_style()
     print("Generating charts...")
-    chart_completions_over_time(records, charts_dir)
+    chart_completions_over_time(submissions, charts_dir)
     chart_sentiment_by_course(feedback, course_stats, charts_dir)
     chart_grades(course_stats, charts_dir)
-    chart_cumulative(records, charts_dir)
+    chart_cumulative(submissions, charts_dir)
     chart_sentiment_pie(feedback, charts_dir)
-    chart_monthly_feedback(records, charts_dir)
-    chart_per_course(records, charts_dir)
+    chart_monthly_feedback(submissions, charts_dir)
+    chart_per_course(submissions, charts_dir)
     print(f"\nAll charts saved to {charts_dir}")
 
 

--- a/.github/skills/agent-academy-report/scripts/generate_charts.py
+++ b/.github/skills/agent-academy-report/scripts/generate_charts.py
@@ -247,7 +247,7 @@ def chart_sentiment_pie(feedback, charts_dir):
     total_neg = sum(1 for r in feedback if r['sentiment'] == 'negative')
     total = total_pos + total_neu + total_neg
 
-    fig, ax = plt.subplots(figsize=(6, 6))
+    fig, ax = plt.subplots(figsize=(3, 3))
     sizes = [total_pos, total_neu, total_neg]
     labels = ['Positive', 'Neutral', 'Negative']
     colors = [GREEN, SLATE_LIGHT, RED]
@@ -326,6 +326,63 @@ def chart_monthly_feedback(records, charts_dir):
     print("  monthly_feedback.png")
 
 
+def _course_slug(course):
+    """Generate a filesystem-safe slug for a course name."""
+    return course.lower().replace(' ', '_').replace(':', '').replace('&', 'and')
+
+
+def chart_per_course(records, charts_dir):
+    """Generate individual submission timeline charts for each course."""
+    for course in COURSE_ORDER:
+        course_records = [r for r in records if r['course'] == course and r.get('date')]
+        if not course_records:
+            continue
+
+        # Weekly aggregation
+        weekly = defaultdict(int)
+        for r in course_records:
+            dt = datetime.strptime(r['date'], '%Y-%m-%d')
+            week_start = dt - timedelta(days=dt.weekday())
+            weekly[week_start.strftime('%Y-%m-%d')] += 1
+
+        weeks_sorted = sorted(weekly.keys())
+        week_dates = [datetime.strptime(w, '%Y-%m-%d') for w in weeks_sorted]
+        counts = [weekly[w] for w in weeks_sorted]
+
+        # Determine color from course group
+        color = BLUE
+        for group, c in COURSE_GROUPS.items():
+            if course.startswith(group) or course == group:
+                color = c
+                break
+
+        fig, ax = plt.subplots(figsize=(10, 4))
+        ax.fill_between(week_dates, counts, alpha=0.15, color=color)
+        ax.plot(week_dates, counts, color=color, linewidth=2)
+
+        # Cumulative on second axis
+        ax2 = ax.twinx()
+        cum = list(np.cumsum(counts))
+        ax2.plot(week_dates, cum, color=NAVY, linewidth=1.5, linestyle='--', alpha=0.5)
+        ax2.set_ylabel('Cumulative', fontsize=10, color=SLATE)
+        ax2.spines['right'].set_color(SLATE_LIGHT)
+        ax2.spines['top'].set_visible(False)
+
+        short = SHORT_NAMES.get(course, course)
+        ax.set_title(f'{short} — Submissions Over Time', fontsize=14, fontweight='bold', pad=12, color=NAVY)
+        ax.set_ylabel('Weekly Submissions', fontsize=10, color=SLATE)
+        ax.xaxis.set_major_formatter(mdates.DateFormatter('%b %d'))
+        ax.xaxis.set_major_locator(mdates.WeekdayLocator(interval=2))
+        plt.xticks(rotation=45, ha='right')
+        ax.set_xlim(week_dates[0], week_dates[-1])
+
+        slug = _course_slug(course)
+        plt.tight_layout()
+        plt.savefig(os.path.join(charts_dir, f'course_{slug}.png'), dpi=180, bbox_inches='tight', facecolor='white')
+        plt.close()
+        print(f"  course_{slug}.png")
+
+
 def main():
     if len(sys.argv) < 2:
         print("Usage: python3 generate_charts.py <workspace-path>")
@@ -355,7 +412,8 @@ def main():
     chart_cumulative(records, charts_dir)
     chart_sentiment_pie(feedback, charts_dir)
     chart_monthly_feedback(records, charts_dir)
-    print(f"\nAll 6 charts saved to {charts_dir}")
+    chart_per_course(records, charts_dir)
+    print(f"\nAll charts saved to {charts_dir}")
 
 
 if __name__ == "__main__":

--- a/.github/skills/agent-academy-report/scripts/generate_charts.py
+++ b/.github/skills/agent-academy-report/scripts/generate_charts.py
@@ -247,7 +247,7 @@ def chart_sentiment_pie(feedback, charts_dir):
     total_neg = sum(1 for r in feedback if r['sentiment'] == 'negative')
     total = total_pos + total_neu + total_neg
 
-    fig, ax = plt.subplots(figsize=(3, 3))
+    fig, ax = plt.subplots(figsize=(4.5, 4.5))
     sizes = [total_pos, total_neu, total_neg]
     labels = ['Positive', 'Neutral', 'Negative']
     colors = [GREEN, SLATE_LIGHT, RED]
@@ -256,23 +256,23 @@ def chart_sentiment_pie(feedback, charts_dir):
         sizes, labels=None, colors=colors, autopct='%1.0f%%',
         startangle=90, pctdistance=0.82,
         wedgeprops=dict(width=0.35, edgecolor='white', linewidth=2),
-        textprops={'fontsize': 12, 'fontweight': 'bold'}
+        textprops={'fontsize': 10, 'fontweight': 'bold'}
     )
     for at in autotexts:
         at.set_color('white')
-        at.set_fontsize(12)
+        at.set_fontsize(10)
         at.set_fontweight('bold')
 
     # Center text
-    ax.text(0, 0.06, f'{total:,}', ha='center', va='center', fontsize=28, fontweight='bold', color=NAVY)
-    ax.text(0, -0.12, 'responses', ha='center', va='center', fontsize=11, color=SLATE)
+    ax.text(0, 0.06, f'{total:,}', ha='center', va='center', fontsize=20, fontweight='bold', color=NAVY)
+    ax.text(0, -0.14, 'responses', ha='center', va='center', fontsize=9, color=SLATE)
 
     # Legend
     legend_labels = [f'{l} ({s:,})' for l, s in zip(labels, sizes)]
-    ax.legend(wedges, legend_labels, loc='lower center', bbox_to_anchor=(0.5, -0.08),
-              framealpha=0.95, edgecolor=GRID_COLOR, fancybox=True, fontsize=11, ncol=3)
+    ax.legend(wedges, legend_labels, loc='lower center', bbox_to_anchor=(0.5, -0.06),
+              framealpha=0.95, edgecolor=GRID_COLOR, fancybox=True, fontsize=9, ncol=3)
 
-    ax.set_title('Overall Feedback Sentiment', fontsize=16, fontweight='bold', pad=15, color=NAVY)
+    ax.set_title('Overall Feedback Sentiment', fontsize=13, fontweight='bold', pad=10, color=NAVY)
     plt.tight_layout()
     plt.savefig(os.path.join(charts_dir, 'sentiment_pie.png'), dpi=180, bbox_inches='tight', facecolor='white')
     plt.close()

--- a/.gitignore
+++ b/.gitignore
@@ -26,5 +26,9 @@ docs/.vitepress/cache
 # VitePress root cache
 /.vitepress/
 
+# Python bytecode
+__pycache__/
+*.pyc
+
 # Report output
 report/


### PR DESCRIPTION
…teps, and grade-based quotes

- Add source/is_closed fields to extract_feedback.py for tracking data origin
- Add per-course submission timeline charts to generate_charts.py
- Reduce sentiment pie chart size (6x6 → 3x3)
- Add Recruit/Operative submission pipeline comparison table
- Add per-course Next Steps (up to 5 prioritized recommendations)
- Change quotes to 10 per course, balanced by grade
- Classify non-badge GitHub issues into courses
- Update SKILL.md with all new instructions