### PR TITLE
Enable the project to build the project without installing docker locally

### DIFF
--- a/docs/special-ops/mcs-mcp/index.md
+++ b/docs/special-ops/mcs-mcp/index.md
@@ -39,7 +39,6 @@ So, MCP and connectors are really **better together**.
 
 - Visual Studio Code installed ([download](https://code.visualstudio.com/download))
 - Node v22 (ideally installed via [nvm for Windows](https://github.com/coreybutler/nvm-windows) or [nvm](https://github.com/nvm-sh/nvm))
-- Docker installed ([download](http://aka.ms/azure-dev/docker-install))
 - Azure Developer CLI installed ([download](https://learn.microsoft.com/azure/developer/azure-developer-cli/install-azd))
 - Azure Subscription (with payment method added)
 - Copilot Studio trial or developer account

--- a/docs/special-ops/mcs-mcp/source/Dockerfile
+++ b/docs/special-ops/mcs-mcp/source/Dockerfile
@@ -7,7 +7,7 @@ COPY package*.json ./
 COPY tsconfig.json ./
 COPY src/ ./src/
 
-RUN --mount=type=cache,target=/root/.npm npm install
+RUN npm install
 
 RUN npm run build
 

--- a/docs/special-ops/mcs-mcp/source/azure.yaml
+++ b/docs/special-ops/mcs-mcp/source/azure.yaml
@@ -10,3 +10,4 @@ services:
     language: js
     docker:
       path: Dockerfile
+      remoteBuild: true


### PR DESCRIPTION
Made changes to the project to enable remote builds and publishing on Azure, removing the dependency on Docker for the build process.
i have tested it