### PR TITLE
fix(docs): correct link text for Copilot Developer Camp guide

### DIFF
--- a/docs/recruit/03-create-a-declarative-agent-for-M365Copilot/index.md
+++ b/docs/recruit/03-create-a-declarative-agent-for-M365Copilot/index.md
@@ -73,7 +73,7 @@ There are more capabilities offered for declarative agents built in Microsoft Co
 > [!TIP]
 >
 > - To learn more about Agent Builder in Microsoft 365 Copilot, head to [Copilot Developer Camp: Lab MAB1 - Build your first agent](https://microsoft.github.io/copilot-camp/pages/make/agent-builder/01-first-agent/)
-> - For pro-development of extending a declarative agent beyond Agent Builder in Microsoft 365 Copilot, head to [Copilot Developer Camp: Lab MAB1 - Build your first agent](https://microsoft.github.io/copilot-camp/pages/extend-m365-copilot/)
+> - For pro-development of extending a declarative agent beyond Agent Builder in Microsoft 365 Copilot, head to [Copilot Developer Camp: Extend Microsoft 365 Copilot](https://microsoft.github.io/copilot-camp/pages/extend-m365-copilot/)
 
 ### Extending Microsoft 365 Copilot with declarative agents built in Copilot Studio
 


### PR DESCRIPTION
Updated the markdown link text to correctly display:

"Copilot Developer Camp: Extend Microsoft 365 Copilot"

Previously, the visible link text did not match the intended title, which could cause confusion for readers navigating the documentation.