### PR TITLE
Fix compliance-packet email send wording to match Cowork UI

### DIFF
--- a/docs/cowork-collective/compliance-packet/index.md
+++ b/docs/cowork-collective/compliance-packet/index.md
@@ -205,14 +205,14 @@ After the three documents are complete, Copilot Cowork will present the leadersh
     ```
 
     > [!NOTE]
-    > If anything needs changing, select **Reject** and tell Copilot Cowork what to fix
+    > If anything needs changing, select **Cancel** and tell Copilot Cowork what to fix
 
 1. Copilot Cowork will draft a new email inline with the files attached that you can review before sending. Review the email then press **Send**
 
     ![Review Email](./assets/send-email-card.png)
 
     > [!WARNING]
-    > Once you **Approve**, the email is sent from your Outlook account to those recipients. For testing, please instruct Copilot Cowork to send the email to yourself so you can see the output and test that it was sent.
+    > Once you press **Send**, the email is sent from your Outlook account to those recipients. For testing, please instruct Copilot Cowork to send the email to yourself so you can see the output and test that it was sent.
 
 1. You'll get a confirmation in Copilot Cowork that the email was sent
 


### PR DESCRIPTION
## Summary
During end-to-end testing of the **Compliance Packet** lab (cowork-collective), the email-send step references buttons that no longer match the Copilot Cowork UI.

The lab says to press **Reject** / **Approve**, but the live "Send draft?" approval card now uses **Cancel** / **Send**.

## Changes
- `If anything needs changing, select Reject` -> **Cancel**
- `Once you Approve, the email is sent` -> `Once you press Send, the email is sent`

## Testing
Tested live: uploaded the 4 sample files, ran the one-shot prompt, all documents + email draft generated correctly (5 Critical / 6 High / 1 Medium risks, correct R-IDs, policy versions). Send-to-self showed a **Send draft?** card with Cancel/Send; clicked Send -> email delivered.

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>