### PR TITLE
Add a feature-flagged Recruit experience switcher

### DIFF
--- a/docs/.vitepress/config.mts
+++ b/docs/.vitepress/config.mts
@@ -5,6 +5,7 @@ import { mermaidPlugin } from "./plugins/vitepress-mermaid";
 import { missionsPlugin } from "./plugins/missions";
 import { previewBannerPlugin } from "./plugins/preview-banner";
 import { downloadFilesPlugin } from "./plugins/download-files";
+import { recruitExperienceSwitcherEnabled } from "./featureFlags";
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url));
 const docsDir = path.resolve(__dirname, "..");
@@ -75,61 +76,118 @@ export default defineConfig({
             text: "Recruit",
             link: "/recruit/",
             collapsed: true,
-            items: [
-              { text: "Course Setup", link: "/recruit/00-course-setup/" },
+            items: ([
               {
-                text: "Introduction to Agents",
-                link: "/recruit/01-introduction-to-agents/",
+                text: "Standard harness",
+                link: "/recruit/",
+                collapsed: true,
+                items: [
+                  { text: "Course Setup", link: "/recruit/00-course-setup/" },
+                  {
+                    text: "Introduction to Agents",
+                    link: "/recruit/01-introduction-to-agents/",
+                  },
+                  {
+                    text: "Copilot Studio Fundamentals",
+                    link: "/recruit/02-copilot-studio-fundamentals/",
+                  },
+                  {
+                    text: "Create A Declarative Agent For M365 Copilot",
+                    link: "/recruit/03-create-a-declarative-agent-for-M365Copilot/",
+                  },
+                  {
+                    text: "Creating A Solution",
+                    link: "/recruit/04-creating-a-solution/",
+                  },
+                  {
+                    text: "Using Prebuilt Agents",
+                    link: "/recruit/05-using-prebuilt-agents/",
+                  },
+                  {
+                    text: "Create Agent From Conversation",
+                    link: "/recruit/06-create-agent-from-conversation/",
+                  },
+                  {
+                    text: "Add New Topic With Trigger",
+                    link: "/recruit/07-add-new-topic-with-trigger/",
+                  },
+                  {
+                    text: "Add Adaptive Cards",
+                    link: "/recruit/08-add-adaptive-card/",
+                  },
+                  {
+                    text: "Add An Agent Flow",
+                    link: "/recruit/09-add-an-agent-flow/",
+                  },
+                  {
+                    text: "Add Event Triggers",
+                    link: "/recruit/10-add-event-triggers/",
+                  },
+                  {
+                    text: "Publish Your Agents",
+                    link: "/recruit/11-publish-your-agent/",
+                  },
+                  {
+                    text: "Understanding Licensing",
+                    link: "/recruit/12-understanding-licensing/",
+                  },
+                  {
+                    text: "Course Completion Badge",
+                    link: "/recruit/course-completion-badges-recruit/",
+                  },
+                ],
               },
               {
-                text: "Copilot Studio Fundamentals",
-                link: "/recruit/02-copilot-studio-fundamentals/",
+                text: "GitHub Copilot harness",
+                link: "/recruit-nextgen/",
+                collapsed: true,
+                items: [
+                  { text: "Course Setup", link: "/recruit-nextgen/00-course-setup/" },
+                  {
+                    text: "Introduction to Agents",
+                    link: "/recruit-nextgen/01-introduction-to-agents/",
+                  },
+                  {
+                    text: "Copilot Studio Fundamentals",
+                    link: "/recruit-nextgen/02-copilot-studio-fundamentals/",
+                  },
+                  {
+                    text: "Creating A Solution",
+                    link: "/recruit-nextgen/03-creating-a-solution/",
+                  },
+                  {
+                    text: "Build with the GitHub Copilot Harness",
+                    link: "/recruit-nextgen/04-build-a-custom-agent/",
+                  },
+                  {
+                    text: "Add a Tool",
+                    link: "/recruit-nextgen/05-add-tools/",
+                  },
+                  {
+                    text: "Add Skills",
+                    link: "/recruit-nextgen/06-add-skills/",
+                  },
+                  {
+                    text: "Automate with Workflows",
+                    link: "/recruit-nextgen/07-automate-with-workflows/",
+                  },
+                  {
+                    text: "Publish Your Agent",
+                    link: "/recruit-nextgen/08-publish-your-agent/",
+                  },
+                  {
+                    text: "Understanding Licensing",
+                    link: "/recruit-nextgen/09-understanding-licensing/",
+                  },
+                  {
+                    text: "Course Completion Badge",
+                    link: "/recruit-nextgen/course-completion-badges-recruit/",
+                  },
+                ],
               },
-              {
-                text: "Create A Declarative Agent For M365 Copilot",
-                link: "/recruit/03-create-a-declarative-agent-for-M365Copilot/",
-              },
-              {
-                text: "Creating A Solution",
-                link: "/recruit/04-creating-a-solution/",
-              },
-              {
-                text: "Using Prebuilt Agents",
-                link: "/recruit/05-using-prebuilt-agents/",
-              },
-              {
-                text: "Create Agent From Conversation",
-                link: "/recruit/06-create-agent-from-conversation/",
-              },
-              {
-                text: "Add New Topic With Trigger",
-                link: "/recruit/07-add-new-topic-with-trigger/",
-              },
-              {
-                text: "Add Adaptive Cards",
-                link: "/recruit/08-add-adaptive-card/",
-              },
-              {
-                text: "Add An Agent Flow",
-                link: "/recruit/09-add-an-agent-flow/",
-              },
-              {
-                text: "Add Event Triggers",
-                link: "/recruit/10-add-event-triggers/",
-              },
-              {
-                text: "Publish Your Agents",
-                link: "/recruit/11-publish-your-agent/",
-              },
-              {
-                text: "Understanding Licensing",
-                link: "/recruit/12-understanding-licensing/",
-              },
-              {
-                text: "Course Completion Badge",
-                link: "/recruit/course-completion-badges-recruit/",
-              },
-            ],
+            ]).flatMap((group, index) =>
+              recruitExperienceSwitcherEnabled ? [group] : index === 0 ? group.items : [],
+            ),
           },
           {
             text: "Operative",

--- a/docs/.vitepress/featureFlags.ts
+++ b/docs/.vitepress/featureFlags.ts
@@ -1,0 +1,2 @@
+// Set to true when the GitHub Copilot harness Recruit path is ready to launch.
+export const recruitExperienceSwitcherEnabled = false;

--- a/docs/.vitepress/theme/components/CoursePathSwitcher.vue
+++ b/docs/.vitepress/theme/components/CoursePathSwitcher.vue
@@ -1,0 +1,135 @@
+<script setup lang="ts">
+import { computed } from "vue";
+import { useData, withBase } from "vitepress";
+import { recruitExperienceSwitcherEnabled } from "../../featureFlags";
+import { coursePathGroups, type CoursePath } from "../coursePaths";
+
+const { page } = useData();
+
+const relativePath = computed(() => `/${page.value.relativePath.replace(/index\.md$/, "")}`);
+
+const activeGroup = computed(() =>
+  coursePathGroups.find((group) =>
+    group.paths.some((path) => relativePath.value.startsWith(path.root)),
+  ),
+);
+
+const isCourseOverview = computed(() =>
+  activeGroup.value?.paths.some((path) => relativePath.value === path.root),
+);
+
+function isActive(path: CoursePath) {
+  return relativePath.value.startsWith(path.root);
+}
+
+function selectPath(path: CoursePath) {
+  if (!isActive(path)) window.location.assign(withBase(path.root));
+}
+</script>
+
+<template>
+  <nav
+    v-if="recruitExperienceSwitcherEnabled && activeGroup && isCourseOverview"
+    class="course-path-switcher"
+    :aria-label="`${activeGroup.course} course path`"
+  >
+    <p class="course-path-switcher__label">Choose your experience</p>
+    <div class="course-path-switcher__options">
+      <a
+        v-for="path in activeGroup.paths"
+        :key="path.root"
+        class="course-path-switcher__option"
+        :class="{ 'course-path-switcher__option--active': isActive(path) }"
+        :href="withBase(path.root)"
+        :aria-current="isActive(path) ? 'page' : undefined"
+        @click.prevent="selectPath(path)"
+      >
+        <span class="course-path-switcher__name">{{ path.label }}</span>
+        <span class="course-path-switcher__description">{{ path.description }}</span>
+      </a>
+    </div>
+  </nav>
+</template>
+
+<style scoped>
+.course-path-switcher {
+  margin: 0 0 2rem;
+  padding: 1rem;
+  border: 2px solid var(--vp-c-brand-1);
+  border-radius: 8px;
+  background: var(--vp-c-brand-soft);
+  box-shadow: 0 4px 14px rgba(0, 0, 0, 0.12);
+}
+
+.course-path-switcher__label {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin: 0 0 0.85rem;
+  color: var(--vp-c-text-1);
+  font-size: 0.95rem;
+  font-weight: 700;
+  letter-spacing: 0;
+}
+
+.course-path-switcher__label::before {
+  width: 0.65rem;
+  height: 0.65rem;
+  border-radius: 50%;
+  background: var(--vp-c-brand-1);
+  content: "";
+  box-shadow: 0 0 0 4px var(--vp-c-bg);
+}
+
+.course-path-switcher__options {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 0.5rem;
+}
+
+.course-path-switcher__option {
+  display: flex;
+  min-width: 0;
+  min-height: 4.25rem;
+  flex-direction: column;
+  justify-content: center;
+  padding: 0.75rem 1rem;
+  border: 1px solid var(--vp-c-divider);
+  border-radius: 6px;
+  background: var(--vp-c-bg);
+  color: var(--vp-c-text-2);
+  text-decoration: none;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease, color 0.15s ease;
+}
+
+.course-path-switcher__option:hover {
+  border-color: var(--vp-c-brand-2);
+  color: var(--vp-c-text-1);
+  box-shadow: 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.course-path-switcher__option--active {
+  border-color: var(--vp-c-brand-1);
+  color: var(--vp-c-text-1);
+  box-shadow: inset 4px 0 0 var(--vp-c-brand-1), 0 2px 8px rgba(0, 0, 0, 0.1);
+}
+
+.course-path-switcher__name {
+  font-size: 0.9rem;
+  font-weight: 700;
+  line-height: 1.35;
+}
+
+.course-path-switcher__description {
+  margin-top: 0.2rem;
+  color: var(--vp-c-text-2);
+  font-size: 0.75rem;
+  line-height: 1.35;
+}
+
+@media (max-width: 640px) {
+  .course-path-switcher__options {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/docs/.vitepress/theme/coursePaths.ts
+++ b/docs/.vitepress/theme/coursePaths.ts
@@ -1,0 +1,28 @@
+export type CoursePath = {
+  label: string;
+  description: string;
+  root: string;
+};
+
+export type CoursePathGroup = {
+  course: string;
+  paths: CoursePath[];
+};
+
+export const coursePathGroups: CoursePathGroup[] = [
+  {
+    course: "Recruit",
+    paths: [
+      {
+        label: "Standard",
+        description: "Uses the standard harness to build conversation logic with topics, triggers, nodes, and agent flows",
+        root: "/recruit/",
+      },
+      {
+        label: "New",
+        description: "Uses the new GitHub Copilot harness to guide agent behavior with instructions, skills, tools, and workflows",
+        root: "/recruit-nextgen/",
+      },
+    ],
+  },
+];

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -17,11 +17,13 @@ import SessionSchedule from "./components/SessionSchedule.vue";
 import VideoLibrary from "./components/VideoLibrary.vue";
 import WorkshopsPage from "./components/WorkshopsPage.vue";
 import HackathonPrizes from "./components/HackathonPrizes.vue";
+import CoursePathSwitcher from "./components/CoursePathSwitcher.vue";
 
 export default {
   extends: DefaultTheme,
   Layout() {
     return h(DefaultTheme.Layout, null, {
+      "doc-before": () => h(CoursePathSwitcher),
       "doc-footer-before": () => h(PageDates),
     });
   },
@@ -41,5 +43,6 @@ export default {
     app.component("VideoLibrary", VideoLibrary);
     app.component("WorkshopsPage", WorkshopsPage);
     app.component("HackathonPrizes", HackathonPrizes);
+    app.component("CoursePathSwitcher", CoursePathSwitcher);
   },
 } satisfies Theme;


### PR DESCRIPTION
## Summary

- add a reusable course experience switcher for the Standard and GitHub Copilot Recruit paths
- group both Recruit curricula under one navigation entry when the feature is enabled
- show the switcher only on course overview pages
- add a single pre-launch feature flag that currently keeps the switcher and GitHub Copilot navigation hidden
- restore the original flat Standard Recruit sidebar while the flag is disabled

## Launch

Set `recruitExperienceSwitcherEnabled` to `true` in `docs/.vitepress/featureFlags.ts` when the GitHub Copilot harness path is ready to launch.

## Validation

- `npm run docs:build`
- browser-tested enabled and disabled flag states
- browser-tested light, dark, desktop, and mobile switcher layouts
- `git diff --check`