### PR TITLE
Added Recruit NextGen to recent changes

### DIFF
--- a/CUSTOM-COMPONENTS.md
+++ b/CUSTOM-COMPONENTS.md
@@ -48,7 +48,7 @@ Renders a filterable, paginated grid of mission cards. Each card shows the missi
 
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
-| `section` | string | — | Filter missions by section: `recruit`, `operative`, `special-ops`, or `cowork-collective`. |
+| `section` | string | — | Filter missions by section: `recruit`, `recruit-nextgen`, `operative`, `special-ops`, or `cowork-collective`. |
 | `sort` | string | `"alphabetical"` | Sort field. Options: `"alphabetical"`, `"last-updated"`, `"level"`, `"first-added"`. |
 | `order` | string | `"ascending"` | Sort direction: `"ascending"` or `"descending"`. |
 | `maxRows` | number | `2` | Maximum rows per page. Enables pagination when set. |
@@ -82,7 +82,7 @@ Show all missions with pagination (4 rows per page):
 
 Missions with `hide: true` in their frontmatter are excluded from every `<missions />` grid, including section, tag, product, and industry listings. The mission page remains available directly, and its `<mission-meta />` component is unaffected.
 
-The `commander-preview`, `recruit-nextgen`, and `operative-v2` folders are excluded from mission data entirely by `EXCLUDED_DIRS` in `docs/.vitepress/plugins/missions/index.ts`, so those missions never appear in a grid and passing one of those slugs to `section` returns nothing.
+The `commander-preview` and `operative-v2` folders are excluded from mission data entirely by `EXCLUDED_DIRS` in `docs/.vitepress/plugins/missions/index.ts`, so those missions never appear in a grid and passing one of those slugs to `section` returns nothing.
 
 **Preview:**
 

--- a/docs/.vitepress/plugins/missions/Missions.vue
+++ b/docs/.vitepress/plugins/missions/Missions.vue
@@ -143,6 +143,7 @@ const props = withDefaults(
 const SECTION_LABELS: Record<string, string> = {
   "special-ops": "Special Ops",
   recruit: "Recruit",
+  "recruit-nextgen": "Recruit NextGen",
   operative: "Operative",
   "cowork-collective": "Cowork Collective",
 };
@@ -440,12 +441,14 @@ const visiblePages = computed<PageItem[]>(() => {
 
 /* Section pill colors */
 .pill-special-ops { background: #fef3c7; color: #92400e; }
-.pill-recruit { background: #d1fae5; color: #065f46; }
+.pill-recruit,
+.pill-recruit-nextgen { background: #d1fae5; color: #065f46; }
 .pill-operative { background: #dbeafe; color: #1e40af; }
 .pill-cowork-collective { background: #ede9fe; color: #5b21b6; }
 
 :root.dark .pill-special-ops { background: #78350f; color: #fef3c7; }
-:root.dark .pill-recruit { background: #064e3b; color: #d1fae5; }
+:root.dark .pill-recruit,
+:root.dark .pill-recruit-nextgen { background: #064e3b; color: #d1fae5; }
 :root.dark .pill-operative { background: #1e3a5f; color: #dbeafe; }
 :root.dark .pill-cowork-collective { background: #4c1d95; color: #ede9fe; }
 

--- a/docs/.vitepress/plugins/missions/index.ts
+++ b/docs/.vitepress/plugins/missions/index.ts
@@ -14,7 +14,6 @@ const EXCLUDED_DIRS = new Set([
   "our-team",
   "data",
   "commander-preview",
-  "recruit-nextgen",
   "operative-v2",
   "recent-changes",
   "tags",
@@ -23,6 +22,7 @@ const EXCLUDED_DIRS = new Set([
 
 const COURSE_BADGES: Record<string, string> = {
   recruit: "/images/mcs-agent-academy-recruit-badge.png",
+  "recruit-nextgen": "/images/mcs-agent-academy-recruit-badge.png",
   operative: "/images/mcs-agent-academy-operative-badge.png",
   commander: "/images/mcs-agent-academy-commander-badge.png",
 };

--- a/docs/.vitepress/plugins/missions/index.ts
+++ b/docs/.vitepress/plugins/missions/index.ts
@@ -22,7 +22,7 @@ const EXCLUDED_DIRS = new Set([
 
 const COURSE_BADGES: Record<string, string> = {
   recruit: "/images/mcs-agent-academy-recruit-badge.png",
-  "recruit-nextgen": "/images/mcs-agent-academy-recruit-badge.png",
+  "recruit-nextgen": "/images/mcs-agent-academy-recruit-nextgen-badge.png",
   operative: "/images/mcs-agent-academy-operative-badge.png",
   commander: "/images/mcs-agent-academy-commander-badge.png",
 };


### PR DESCRIPTION
This pull request adds support for a new `recruit-nextgen` mission section throughout the missions grid component and related documentation. It ensures that `recruit-nextgen` missions are now included in listings, have appropriate labels, badges, and pill styles, and are no longer excluded from mission data.

**Support for new `recruit-nextgen` mission section:**

* Updated the `section` prop documentation for the missions grid component to include `recruit-nextgen` as a valid option.
* Removed `recruit-nextgen` from the list of excluded directories in `EXCLUDED_DIRS`, so missions in this folder are now included in grids.
* Added a label for `recruit-nextgen` to `SECTION_LABELS` in `Missions.vue` for proper display in the UI.
* Added a badge image for `recruit-nextgen` to `COURSE_BADGES` so it displays a badge like other sections.

**UI and styling updates:**

* Updated CSS to ensure `recruit-nextgen` pills use the same color scheme as `recruit` in both light and dark modes.

**Documentation update:**

* Updated the documentation to reflect that only `commander-preview` and `operative-v2` folders are excluded from mission data, not `recruit-nextgen`.