### PR TITLE
Fix list numbering in 04-build-a-custom-agent (recruit-nextgen)

### DIFF
--- a/docs/recruit-nextgen/04-build-a-custom-agent/index.md
+++ b/docs/recruit-nextgen/04-build-a-custom-agent/index.md
@@ -240,7 +240,7 @@ Before starting this lab, make sure you have:
 
     ![Add SharePoint site to the agent](./assets/04-add-sharepoint-site-to-the-agent.png)
 
-Now, we'll now add another internal knowledge source by uploading a document directly to our agent.
+    Now, we'll now add another internal knowledge source by uploading a document directly to our agent.
 
 1. In the **Knowledge** section, select **Add+** icon.
 


### PR DESCRIPTION
The intro line for the document-upload knowledge source ("Now, we'll now add another internal knowledge source by uploading a document directly to our agent.") was at the top level, which reset the ordered-list numbering that follows.

This indents the line (4 spaces) so it nests within the ordered list and the numbering continues correctly.