### PR TITLE
Fix download-files zip packaging

### DIFF
--- a/CUSTOM-COMPONENTS.md
+++ b/CUSTOM-COMPONENTS.md
@@ -189,6 +189,9 @@ Button with a product icon:
 
 **When to use:** On mission pages where learners need to download starter files, solution zips, or sample data. The `path` must point to a folder under `docs/` whose files are collected at build time by the Vite virtual module plugin.
 
+> [!TIP]
+> If a bundle folder already contains a `.zip` archive, the component downloads that archive directly instead of nesting it inside a second zip. This avoids the common "zip inside a zip" issue when the prepared asset is itself a `.zip` file.
+
 **No-JavaScript fallback:** The zip is generated in the browser with JSZip, so it can't be produced when JavaScript is disabled or blocked. In that case a `<noscript>` fallback renders a plain link to the browsable GitHub folder for the same `path` (`https://github.com/microsoft/agent-academy/tree/main/docs/<path>`), so learners can still reach and download the files manually.
 
 **Preview:**

--- a/docs/.vitepress/plugins/download-files/DownloadFiles.vue
+++ b/docs/.vitepress/plugins/download-files/DownloadFiles.vue
@@ -44,6 +44,39 @@ const githubFolderUrl = computed(
 const zipName = computed(() => `${folderName.value}.zip`);
 
 const buttonLabel = computed(() => props.label || `Download ${zipName.value}`);
+const archiveFiles = computed(() =>
+  files.value.filter((fileName) => fileName.toLowerCase().endsWith(".zip"))
+);
+
+async function fetchFileBlob(fileName: string): Promise<Blob> {
+  const base = site.value.base || "/";
+  const rawGitHub = "https://raw.githubusercontent.com/microsoft/agent-academy/main/docs/";
+
+  const localUrl = `${base}${normalizedPath.value}/${fileName}`;
+  let response = await fetch(localUrl);
+  if (!response.ok) {
+    const ghUrl = `${rawGitHub}${normalizedPath.value}/${fileName}`;
+    response = await fetch(ghUrl);
+  }
+  if (!response.ok) {
+    throw new Error(`Failed to fetch ${fileName} (${response.status})`);
+  }
+
+  return response.blob();
+}
+
+function triggerDownload(blob: Blob, fileName: string) {
+  const url = URL.createObjectURL(blob);
+  const a = document.createElement("a");
+  a.href = url;
+  a.download = fileName;
+  document.body.appendChild(a);
+  a.click();
+  document.body.removeChild(a);
+  setTimeout(() => {
+    URL.revokeObjectURL(url);
+  }, 1000);
+}
 
 type Status = "idle" | "loading" | "success" | "error";
 const status = ref<Status>("idle");
@@ -76,39 +109,37 @@ async function download() {
   errorMessage.value = "";
 
   try {
-    const zip = new JSZip();
-    const base = site.value.base || "/";
-    const rawGitHub = "https://raw.githubusercontent.com/microsoft/agent-academy/main/docs/";
+    if (archiveFiles.value.length === 1) {
+      const zipFileName = archiveFiles.value[0];
+      const zipBlob = await fetchFileBlob(zipFileName);
+      triggerDownload(zipBlob, zipFileName);
 
-    const fetchPromises = files.value.map(async (fileName) => {
-      const localUrl = `${base}${normalizedPath.value}/${fileName}`;
-      let response = await fetch(localUrl);
-      if (!response.ok) {
-        // Fall back to raw GitHub download URL
-        const ghUrl = `${rawGitHub}${normalizedPath.value}/${fileName}`;
-        response = await fetch(ghUrl);
-      }
-      if (!response.ok) {
-        throw new Error(`Failed to fetch ${fileName} (${response.status})`);
-      }
-      const blob = await response.blob();
+      status.value = "success";
+      successTimer = setTimeout(() => {
+        status.value = "idle";
+      }, 2500);
+      return;
+    }
+
+    const payloadFiles = files.value.filter(
+      (fileName) => !fileName.toLowerCase().endsWith(".zip")
+    );
+    if (payloadFiles.length === 0) {
+      status.value = "error";
+      errorMessage.value = "No downloadable content found in this folder.";
+      return;
+    }
+
+    const zip = new JSZip();
+    const fetchPromises = payloadFiles.map(async (fileName) => {
+      const blob = await fetchFileBlob(fileName);
       zip.file(fileName, blob);
     });
 
     await Promise.all(fetchPromises);
 
     const zipBlob = await zip.generateAsync({ type: "blob" });
-    const url = URL.createObjectURL(zipBlob);
-
-    const a = document.createElement("a");
-    a.href = url;
-    a.download = zipName.value;
-    document.body.appendChild(a);
-    a.click();
-    document.body.removeChild(a);
-    setTimeout(() => {
-      URL.revokeObjectURL(url);
-    }, 1000);
+    triggerDownload(zipBlob, zipName.value);
 
     status.value = "success";
     successTimer = setTimeout(() => {


### PR DESCRIPTION
## Summary

This fix prevents the  component from creating a zip file inside another zip when a lesson folder already contains a prepared  asset (for example, a packaged skill or starter solution).

The component now detects that scenario and downloads the existing archive directly, while preserving the previous JSZip behavior for folder contents that are not already compressed.

## Changes

- detect existing  assets in a  bundle
- download the archive directly instead of packaging it into a new zip
- keep the JSZip flow for ordinary file collections
- document the behavior in the custom components reference