### PR TITLE
Add harness frontmatter to Recruit and Recruit NextGen missions

### DIFF
--- a/docs/recruit-nextgen/00-course-setup/index.md
+++ b/docs/recruit-nextgen/00-course-setup/index.md
@@ -11,6 +11,7 @@ short-description: 'Set up your dev environment, Copilot Studio trial, and Share
 difficulty: 1
 codename: OPERATION DEPLOYMENT READY
 time: 30
+harness: github-copilot
 tags:
   - setup
 products:

--- a/docs/recruit-nextgen/01-introduction-to-agents/index.md
+++ b/docs/recruit-nextgen/01-introduction-to-agents/index.md
@@ -11,6 +11,7 @@ short-description: 'Learn how agents reason, use knowledge and tools, and operat
 difficulty: 1
 codename: OPERATION AI AGENT DECODE
 time: 15
+harness: github-copilot
 tags:
   - fundamentals
 products:

--- a/docs/recruit-nextgen/02-copilot-studio-fundamentals/index.md
+++ b/docs/recruit-nextgen/02-copilot-studio-fundamentals/index.md
@@ -11,6 +11,7 @@ short-description: 'Explore Copilot Studio harnesses, agent building blocks, wor
 difficulty: 1
 codename: OPERATION TOOLBOX
 time: 20
+harness: github-copilot
 tags:
   - fundamentals
 products:

--- a/docs/recruit-nextgen/03-creating-a-solution/index.md
+++ b/docs/recruit-nextgen/03-creating-a-solution/index.md
@@ -11,6 +11,7 @@ short-description: Package your agent into a reusable solution for environment m
 difficulty: 1
 codename: OPERATION CTRL-ALT-PACKAGE
 time: 45
+harness: github-copilot
 tags:
   - solutions
 products:

--- a/docs/recruit-nextgen/04-build-a-custom-agent/index.md
+++ b/docs/recruit-nextgen/04-build-a-custom-agent/index.md
@@ -11,6 +11,7 @@ short-description: Create an agent powered by the GitHub Copilot harness using A
 difficulty: 1
 codename: OPERATION ENGINE SHIFT
 time: 60
+harness: github-copilot
 tags: [fundamentals, solutions]
 products:
   - copilot-studio

--- a/docs/recruit-nextgen/05-add-tools/index.md
+++ b/docs/recruit-nextgen/05-add-tools/index.md
@@ -11,6 +11,7 @@ short-description: Add a SharePoint Get items tool so your agent can take action
 difficulty: 1
 codename: OPERATION TOOL UP
 time: 30
+harness: github-copilot
 tags:
    - automation
    - grounding

--- a/docs/recruit-nextgen/06-add-skills/index.md
+++ b/docs/recruit-nextgen/06-add-skills/index.md
@@ -11,6 +11,7 @@ short-description: Use a GitHub Copilot harness Skill to create a reusable devic
 difficulty: 1
 codename: OPERATION SKILL BOOST
 time: 30
+harness: github-copilot
 tags:
     - custom-skills
     - instructions

--- a/docs/recruit-nextgen/07-automate-with-workflows/index.md
+++ b/docs/recruit-nextgen/07-automate-with-workflows/index.md
@@ -11,6 +11,7 @@ short-description: Automate a device request with a workflow and call it from yo
 difficulty: 1
 codename: OPERATION AUTOMATION POWERHOUSE
 time: 60
+harness: github-copilot
 tags:
   - automation
   - triggers

--- a/docs/recruit-nextgen/08-publish-your-agent/index.md
+++ b/docs/recruit-nextgen/08-publish-your-agent/index.md
@@ -11,6 +11,7 @@ short-description: 'Publish your agent'
 difficulty: 1
 codename: OPERATION ROLL OUT
 time: 15
+harness: github-copilot
 tags:
   - publishing
 products:

--- a/docs/recruit-nextgen/09-understanding-licensing/index.md
+++ b/docs/recruit-nextgen/09-understanding-licensing/index.md
@@ -11,6 +11,7 @@ short-description: Learn how licensing and usage-based billing work for the GitH
 difficulty: 1
 codename: OPERATION KNOW WHAT YOU OWE
 time: 20
+harness: github-copilot
 tags:
   - licensing
 products:

--- a/docs/recruit-nextgen/course-completion-badges-recruit/index.md
+++ b/docs/recruit-nextgen/course-completion-badges-recruit/index.md
@@ -11,6 +11,7 @@ short-description: Claim your badge and mark your achievement!
 difficulty: 1
 codename: OPERATION COURSE COMPLETION
 time: 5
+harness: github-copilot
 tags:
   - completion
 products:

--- a/docs/recruit/00-course-setup/index.md
+++ b/docs/recruit/00-course-setup/index.md
@@ -9,6 +9,7 @@ short-description: 'Set up your dev environment, Copilot Studio trial, and Share
 difficulty: 1
 codename: OPERATION DEPLOYMENT READY
 time: 30
+harness: standard
 tags:
   - setup
 products:

--- a/docs/recruit/01-introduction-to-agents/index.md
+++ b/docs/recruit/01-introduction-to-agents/index.md
@@ -11,6 +11,7 @@ short-description: >-
 difficulty: 1
 codename: OPERATION AI AGENT DECODE
 time: 30
+harness: standard
 tags:
   - fundamentals
 products:

--- a/docs/recruit/02-copilot-studio-fundamentals/index.md
+++ b/docs/recruit/02-copilot-studio-fundamentals/index.md
@@ -9,6 +9,7 @@ short-description: 'Learn the building blocks: knowledge, skills, autonomy'
 difficulty: 1
 codename: OPERATION CORE PROTOCOL
 time: 30
+harness: standard
 tags:
   - fundamentals
 products:

--- a/docs/recruit/03-create-a-declarative-agent-for-M365Copilot/index.md
+++ b/docs/recruit/03-create-a-declarative-agent-for-M365Copilot/index.md
@@ -9,6 +9,7 @@ short-description: 'Add your own agent to the Microsoft 365 Copilot, grounded in
 difficulty: 1
 codename: OPERATION COPILOT EXTENSION
 time: 60
+harness: standard
 tags:
   - declarative-agents
 products:

--- a/docs/recruit/04-creating-a-solution/index.md
+++ b/docs/recruit/04-creating-a-solution/index.md
@@ -9,6 +9,7 @@ short-description: Package your agent into a reusable solution for environment m
 difficulty: 1
 codename: OPERATION CTRL-ALT-PACKAGE
 time: 45
+harness: standard
 tags:
   - solutions
 products:

--- a/docs/recruit/05-using-prebuilt-agents/index.md
+++ b/docs/recruit/05-using-prebuilt-agents/index.md
@@ -9,6 +9,7 @@ short-description: Use and customize a template agent to accelerate setup
 difficulty: 1
 codename: OPERATION SAFE TRAVELS
 time: 30
+harness: standard
 tags:
   - prebuilt-agents
 products:

--- a/docs/recruit/06-create-agent-from-conversation/index.md
+++ b/docs/recruit/06-create-agent-from-conversation/index.md
@@ -9,6 +9,7 @@ short-description: Create a new agent grounded in knowledge sources
 difficulty: 1
 codename: OPERATION AGENT FORGE
 time: 75
+harness: standard
 tags:
   - declarative-agents
 products:

--- a/docs/recruit/07-add-new-topic-with-trigger/index.md
+++ b/docs/recruit/07-add-new-topic-with-trigger/index.md
@@ -9,6 +9,7 @@ short-description: Use Topics to define custom question/answer paths
 difficulty: 1
 codename: OPERATION STAY ON TOPIC
 time: 60
+harness: standard
 tags:
   - topics
   - triggers

--- a/docs/recruit/08-add-adaptive-card/index.md
+++ b/docs/recruit/08-add-adaptive-card/index.md
@@ -9,6 +9,7 @@ short-description: Build an Adaptive Card using Power Fx and SharePoint
 difficulty: 1
 codename: OPERATION INTERFACE UPLIFT
 time: 45
+harness: standard
 tags:
   - adaptive-cards
 products:

--- a/docs/recruit/09-add-an-agent-flow/index.md
+++ b/docs/recruit/09-add-an-agent-flow/index.md
@@ -9,6 +9,7 @@ short-description: Use Adaptive Card input to trigger back-end flows
 difficulty: 1
 codename: OPERATION AUTOMATION POWERHOUSE
 time: 30
+harness: standard
 tags:
   - automation
 products:

--- a/docs/recruit/10-add-event-triggers/index.md
+++ b/docs/recruit/10-add-event-triggers/index.md
@@ -9,6 +9,7 @@ short-description: Enable your agent to act autonomously using event-based logic
 difficulty: 1
 codename: OPERATION GHOST ROUTINE
 time: 45
+harness: standard
 tags:
   - automation
   - triggers

--- a/docs/recruit/11-publish-your-agent/index.md
+++ b/docs/recruit/11-publish-your-agent/index.md
@@ -9,6 +9,7 @@ short-description: Deploy your agent to Microsoft Teams and Microsoft 365 Copilo
 difficulty: 1
 codename: OPERATION PUBLISH PUBLISH PUBLISH
 time: 30
+harness: standard
 tags:
   - publishing
 products:

--- a/docs/recruit/12-understanding-licensing/index.md
+++ b/docs/recruit/12-understanding-licensing/index.md
@@ -9,6 +9,7 @@ short-description: Learn how licensing and billing works with Copilot Studio
 difficulty: 1
 codename: OPERATION KNOW WHAT YOU OWE
 time: 15
+harness: standard
 tags:
   - licensing
 products:

--- a/docs/recruit/course-completion-badges-recruit/index.md
+++ b/docs/recruit/course-completion-badges-recruit/index.md
@@ -9,6 +9,7 @@ short-description: Claim your badge and mark your achievement!
 difficulty: 1
 codename: OPERATION COURSE COMPLETION
 time: 5
+harness: standard
 tags:
   - completion
 products:


### PR DESCRIPTION
Special Ops missions declare a `harness` field in their frontmatter, which the `<mission-meta />` component renders as a harness pill. Recruit and Recruit NextGen missions were missing it, so learners could not see at a glance which Copilot Studio harness a mission targets.

This adds the field to all 25 Recruit and Recruit NextGen mission pages, placed directly after `time` to match the ordering used in Special Ops:

- Recruit NextGen (11 pages): `harness: github-copilot`
- Recruit (14 pages): `harness: standard`

Notes for reviewers:

- `docs/recruit/choose/index.md` was intentionally skipped. It is the path chooser page, not a mission, and already explains both harnesses in prose.
- `scripts/validate-frontmatter.mjs` only scopes `special-ops` and `cowork-collective`, so these course pages are not machine validated. The values used here are the ones the validator already accepts (`standard`, `copilot-chat`, `github-copilot`). Running the validator still passes.
- Content is unchanged; this is frontmatter only.