### PR TITLE
Add Copilot Credits estimates to Recruit NextGen

### DIFF
--- a/.markdownlint.jsonc
+++ b/.markdownlint.jsonc
@@ -28,7 +28,7 @@
   // MD033/no-inline-html : Inline HTML : https://github.com/DavidAnson/markdownlint/blob/v0.32.1/doc/md033.md
   // Justification: VitePress pages use Vue script setup and custom components
   "MD033": {
-    "allowed_elements": [ "script", "mission-meta", "missions", "breadcrumb", "products-index", "tags-index", "VPTeamMembers", "analytics-tag", "industries-index", "action-button", "download-files", "preview-banner", "VideoLibrary", "SessionSchedule", "WorkshopsPage", "HackathonPrizes", "course-path-cards" ]
+    "allowed_elements": [ "script", "mission-meta", "missions", "breadcrumb", "products-index", "tags-index", "VPTeamMembers", "analytics-tag", "industries-index", "action-button", "download-files", "preview-banner", "VideoLibrary", "SessionSchedule", "WorkshopsPage", "HackathonPrizes", "course-path-cards", "course-credits", "mission-credits" ]
   },
 
   // MD012/no-multiple-blanks — not enforced

--- a/CONTRIBUTING-COURSES.md
+++ b/CONTRIBUTING-COURSES.md
@@ -66,6 +66,7 @@ short-description: 'A concise description of this mission'
 difficulty: 1
 codename: OPERATION AI AGENT DECODE
 time: 30
+credits: 0
 tags:
   - fundamentals
 products:
@@ -87,6 +88,7 @@ last-edited-date: 2026-03-13
 | `difficulty` | number (1–5) | Yes | Difficulty level. Recruit = 1, Operative = 2, Commander = 3+. |
 | `codename` | string | Yes | Thematic operation name in ALL CAPS (for example `OPERATION SECRET DIRECTIVE`). |
 | `time` | number | Yes | Estimated completion time in minutes. |
+| `credits` | number or `[min, max]` | No | Non-binding estimate of the Copilot Credits the mission consumes, written as a `[min, max]` range (for example `[200, 600]`). Use `0` for missions that only involve reading, tenant setup, or manual configuration. Omit the field entirely when the course doesn't consume Copilot Credits. |
 | `tags` | string[] | Yes | Array of tag slugs from `docs/.vitepress/data/tags.json`. |
 | `products` | string[] | Yes | Array of product slugs from `docs/.vitepress/data/products.json`. |
 | `industries` | string[] | Yes | Array of industry slugs from `docs/.vitepress/data/industries.json`. |
@@ -159,6 +161,9 @@ Next up is [Mission NN+1](../next-mission/index.md): Next Mission Title
 ### Key rules
 
 - The `<mission-meta />` component renders the codename, difficulty stars, time estimate, and product/tag/industry pills automatically from the frontmatter. Place it directly after the H1 title.
+- The `<mission-credits />` component renders a mission's `credits` range in a callout box. Place it directly under `<mission-meta />` on every mission of a course that consumes Copilot Credits.
+- The `<course-credits section="course-slug" />` component sums both ends of the `credits` range across every mission in a course. Place it on the course overview page (`docs/<course>/index.md`). It accepts optional markdown slot content for course-specific context about why the path consumes credits. Both boxes carry a short note explaining the estimate is non-binding.
+- Missions with a non-zero `credits` value must include a `## 🪙 Copilot Credits Estimate` section, placed at the end of the mission directly before Tactical Resources. The `<mission-credits />` box links to its `#copilot-credits-estimate` anchor. It explains how the range was derived with a per-activity breakdown table, so the estimate is auditable rather than arbitrary.
 - Always put theory (concept explanation) **before** the corresponding lab.
 - Use H2 (`##`) for top-level labs: `## Lab 1: Title`.
 - Use H3 (`###`) for sub-labs: `### Lab 1.1: Sub-title`.

--- a/docs/.vitepress/plugins/credits/CourseCredits.vue
+++ b/docs/.vitepress/plugins/credits/CourseCredits.vue
@@ -1,0 +1,112 @@
+<template>
+  <div v-if="hasEstimate" class="course-credits">
+    <div class="course-credits-head">
+      <span class="course-credits-label">🪙 Course Copilot Credits Estimation</span>
+    </div>
+    <p class="course-credits-total">
+      {{ totalLabel }}
+      <span class="course-credits-sub">across {{ missionCount }} missions</span>
+    </p>
+    <div v-if="$slots.default" class="course-credits-note course-credits-intro">
+      <slot />
+    </div>
+    <p class="course-credits-note">
+      The course total is the sum of the per-mission estimates shown on each
+      mission page. This is a non-binding estimate. We aim for a conservative
+      guess, but your actual Copilot Credits consumption depends on how much you
+      experiment, re-prompt, and test, and it may end up higher than the range
+      shown.
+    </p>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import { missions } from "virtual:missions-data";
+
+const props = defineProps<{ section: string }>();
+
+const sectionMissions = computed(() =>
+  missions.filter((m) => m.section === props.section && m.credits !== null)
+);
+
+const total = computed(() =>
+  sectionMissions.value.reduce(
+    (acc, m) => ({
+      min: acc.min + (m.credits?.min ?? 0),
+      max: acc.max + (m.credits?.max ?? 0),
+    }),
+    { min: 0, max: 0 }
+  )
+);
+
+const totalLabel = computed(() => {
+  const fmt = (n: number) => n.toLocaleString("en-US");
+  const { min, max } = total.value;
+  return min === max ? `~${fmt(max)} credits` : `${fmt(min)} - ${fmt(max)} credits`;
+});
+
+const missionCount = computed(() => sectionMissions.value.length);
+
+const hasEstimate = computed(() => missionCount.value > 0);
+</script>
+
+<style scoped>
+.course-credits {
+  padding: 0.9rem 1.1rem;
+  margin: 1rem 0 1.25rem;
+  border: 1px solid var(--vp-c-divider);
+  border-left: 3px solid var(--vp-c-brand-1);
+  border-radius: 8px;
+  background: var(--vp-c-bg-soft);
+}
+
+.course-credits-head {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.course-credits-label {
+  font-weight: 600;
+  color: var(--vp-c-text-2);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+}
+
+.course-credits-total {
+  margin: 0.35rem 0 0;
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: var(--vp-c-text-1);
+  line-height: 1.3;
+}
+
+.course-credits-sub {
+  font-size: 0.8rem;
+  font-weight: 400;
+  color: var(--vp-c-text-2);
+}
+
+.course-credits-note {
+  margin: 0.5rem 0 0;
+  font-size: 0.8rem;
+  line-height: 1.5;
+  color: var(--vp-c-text-2);
+}
+
+.course-credits-intro {
+  color: var(--vp-c-text-1);
+}
+
+.course-credits-intro :deep(p) {
+  margin: 0;
+  font-size: inherit;
+  line-height: inherit;
+}
+
+.course-credits-intro :deep(p + p) {
+  margin-top: 0.5rem;
+}
+</style>

--- a/docs/.vitepress/plugins/credits/MissionCredits.vue
+++ b/docs/.vitepress/plugins/credits/MissionCredits.vue
@@ -11,8 +11,7 @@
         <a href="#copilot-credits-estimate">See how this was calculated</a>.
       </template>
       <template v-else>
-        This mission only involves reading and manual configuration, which
-        doesn't consume Copilot Credits.
+        Nothing in this mission consumes Copilot Credits.
       </template>
     </p>
   </div>
@@ -21,20 +20,11 @@
 <script setup lang="ts">
 import { computed } from "vue";
 import { useData } from "vitepress";
+import { parseCredits } from "./parseCredits";
 
 const { frontmatter } = useData();
 
-const credits = computed(() => {
-  const value = frontmatter.value.credits;
-  if (value === null || value === undefined || value === "") return null;
-
-  const nums = (Array.isArray(value) ? value : [value, value])
-    .map(Number)
-    .filter((n: number) => Number.isFinite(n) && n >= 0);
-
-  if (nums.length !== 2) return null;
-  return { min: Math.min(...nums), max: Math.max(...nums) };
-});
+const credits = computed(() => parseCredits(frontmatter.value.credits));
 
 const hasBreakdown = computed(() => (credits.value?.max ?? 0) > 0);
 

--- a/docs/.vitepress/plugins/credits/MissionCredits.vue
+++ b/docs/.vitepress/plugins/credits/MissionCredits.vue
@@ -1,0 +1,90 @@
+<template>
+  <div v-if="credits" class="mission-credits">
+    <div class="mission-credits-head">
+      <span class="mission-credits-label">🪙 Mission Copilot Credits Estimation</span>
+    </div>
+    <p class="mission-credits-total">{{ creditsLabel }}</p>
+    <p class="mission-credits-note">
+      <template v-if="hasBreakdown">
+        Non-binding estimate. Your actual consumption depends on how much you
+        experiment, re-prompt, and test.
+        <a href="#copilot-credits-estimate">See how this was calculated</a>.
+      </template>
+      <template v-else>
+        This mission only involves reading and manual configuration, which
+        doesn't consume Copilot Credits.
+      </template>
+    </p>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed } from "vue";
+import { useData } from "vitepress";
+
+const { frontmatter } = useData();
+
+const credits = computed(() => {
+  const value = frontmatter.value.credits;
+  if (value === null || value === undefined || value === "") return null;
+
+  const nums = (Array.isArray(value) ? value : [value, value])
+    .map(Number)
+    .filter((n: number) => Number.isFinite(n) && n >= 0);
+
+  if (nums.length !== 2) return null;
+  return { min: Math.min(...nums), max: Math.max(...nums) };
+});
+
+const hasBreakdown = computed(() => (credits.value?.max ?? 0) > 0);
+
+const creditsLabel = computed(() => {
+  const c = credits.value;
+  if (!c) return "";
+  if (c.max === 0) return "None expected";
+  const fmt = (n: number) => n.toLocaleString("en-US");
+  return c.min === c.max
+    ? `~${fmt(c.max)} credits`
+    : `${fmt(c.min)} - ${fmt(c.max)} credits`;
+});
+</script>
+
+<style scoped>
+.mission-credits {
+  padding: 0.9rem 1.1rem;
+  margin: 1rem 0 1.25rem;
+  border: 1px solid var(--vp-c-divider);
+  border-left: 3px solid var(--vp-c-brand-1);
+  border-radius: 8px;
+  background: var(--vp-c-bg-soft);
+}
+
+.mission-credits-head {
+  display: flex;
+  align-items: center;
+  gap: 0.4rem;
+}
+
+.mission-credits-label {
+  font-weight: 600;
+  color: var(--vp-c-text-2);
+  font-size: 0.75rem;
+  text-transform: uppercase;
+  letter-spacing: 0.07em;
+}
+
+.mission-credits-total {
+  margin: 0.35rem 0 0;
+  font-size: 1.15rem;
+  font-weight: 700;
+  color: var(--vp-c-text-1);
+  line-height: 1.3;
+}
+
+.mission-credits-note {
+  margin: 0.5rem 0 0;
+  font-size: 0.8rem;
+  line-height: 1.5;
+  color: var(--vp-c-text-2);
+}
+</style>

--- a/docs/.vitepress/plugins/credits/parseCredits.ts
+++ b/docs/.vitepress/plugins/credits/parseCredits.ts
@@ -1,0 +1,29 @@
+export interface CreditsRange {
+  min: number;
+  max: number;
+}
+
+/**
+ * Parses a mission's `credits` frontmatter value into a range.
+ *
+ * Accepts a single non-negative number (rendered as an exact figure) or a
+ * two-entry `[min, max]` array. Anything else is rejected outright rather than
+ * coerced, so malformed frontmatter surfaces as a missing estimate instead of a
+ * plausible-looking but wrong one.
+ */
+export function parseCredits(value: unknown): CreditsRange | null {
+  if (value === null || value === undefined || value === "") return null;
+
+  const raw = Array.isArray(value) ? value : [value, value];
+  if (raw.length !== 2) return null;
+
+  const nums = raw.map((entry) => {
+    if (typeof entry === "number") return entry;
+    if (typeof entry === "string" && entry.trim() !== "") return Number(entry);
+    return Number.NaN;
+  });
+
+  if (nums.some((n) => !Number.isFinite(n) || n < 0)) return null;
+
+  return { min: Math.min(...nums), max: Math.max(...nums) };
+}

--- a/docs/.vitepress/plugins/credits/parseCredits.ts
+++ b/docs/.vitepress/plugins/credits/parseCredits.ts
@@ -7,8 +7,9 @@ export interface CreditsRange {
  * Parses a mission's `credits` frontmatter value into a range.
  *
  * Accepts a single non-negative number (rendered as an exact figure) or a
- * two-entry `[min, max]` array. Anything else is rejected outright rather than
- * coerced, so malformed frontmatter surfaces as a missing estimate instead of a
+ * two-entry `[min, max]` array where `min` is not greater than `max`. Anything
+ * else, including a reversed range, is rejected outright rather than coerced,
+ * so malformed frontmatter surfaces as a missing estimate instead of a
  * plausible-looking but wrong one.
  */
 export function parseCredits(value: unknown): CreditsRange | null {
@@ -25,5 +26,8 @@ export function parseCredits(value: unknown): CreditsRange | null {
 
   if (nums.some((n) => !Number.isFinite(n) || n < 0)) return null;
 
-  return { min: Math.min(...nums), max: Math.max(...nums) };
+  const [min, max] = nums;
+  if (min > max) return null;
+
+  return { min, max };
 }

--- a/docs/.vitepress/plugins/mission-meta/MissionMeta.vue
+++ b/docs/.vitepress/plugins/mission-meta/MissionMeta.vue
@@ -237,6 +237,7 @@ const hasAnything = computed(() => codename.value || difficulty.value || timeMin
 .meta-pills {
   display: flex;
   flex-wrap: wrap;
+  align-items: center;
   gap: 0.3rem;
 }
 

--- a/docs/.vitepress/plugins/missions/index.ts
+++ b/docs/.vitepress/plugins/missions/index.ts
@@ -2,6 +2,7 @@ import type { Plugin } from "vite";
 import path from "node:path";
 import fs from "node:fs";
 import matter from "gray-matter";
+import { parseCredits, type CreditsRange } from "../credits/parseCredits";
 
 const VIRTUAL_MODULE_ID = "virtual:missions-data";
 const RESOLVED_ID = "\0" + VIRTUAL_MODULE_ID;
@@ -39,18 +40,7 @@ interface MissionData {
   lastUpdated: number;
   createdAt: number;
   preview: boolean;
-  credits: { min: number; max: number } | null;
-}
-
-function parseCredits(value: unknown): { min: number; max: number } | null {
-  if (value === null || value === undefined || value === "") return null;
-
-  const nums = (Array.isArray(value) ? value : [value, value])
-    .map(Number)
-    .filter((n) => Number.isFinite(n) && n >= 0);
-
-  if (nums.length !== 2) return null;
-  return { min: Math.min(...nums), max: Math.max(...nums) };
+  credits: CreditsRange | null;
 }
 
 function extractH1(content: string): string {

--- a/docs/.vitepress/plugins/missions/index.ts
+++ b/docs/.vitepress/plugins/missions/index.ts
@@ -39,6 +39,18 @@ interface MissionData {
   lastUpdated: number;
   createdAt: number;
   preview: boolean;
+  credits: { min: number; max: number } | null;
+}
+
+function parseCredits(value: unknown): { min: number; max: number } | null {
+  if (value === null || value === undefined || value === "") return null;
+
+  const nums = (Array.isArray(value) ? value : [value, value])
+    .map(Number)
+    .filter((n) => Number.isFinite(n) && n >= 0);
+
+  if (nums.length !== 2) return null;
+  return { min: Math.min(...nums), max: Math.max(...nums) };
 }
 
 function extractH1(content: string): string {
@@ -113,6 +125,7 @@ function loadMissions(docsDir: string): MissionData[] {
           frontmatter.preview === true ||
           (typeof frontmatter.preview === "string" &&
             frontmatter.preview.trim() !== ""),
+        credits: parseCredits(frontmatter.credits),
       });
     }
   }

--- a/docs/.vitepress/plugins/missions/missions.d.ts
+++ b/docs/.vitepress/plugins/missions/missions.d.ts
@@ -11,6 +11,7 @@ declare module "virtual:missions-data" {
     lastUpdated: number;
     createdAt: number;
     preview: boolean;
+    credits: { min: number; max: number } | null;
   }
 
   export const missions: MissionData[];

--- a/docs/.vitepress/theme/index.ts
+++ b/docs/.vitepress/theme/index.ts
@@ -13,6 +13,8 @@ import PreviewBanner from "../plugins/preview-banner/PreviewBanner.vue";
 import AnalyticsTag from "../plugins/analytics-tag/AnalyticsTag.vue";
 import DownloadFiles from "../plugins/download-files/DownloadFiles.vue";
 import ActionButton from "../plugins/action-button/ActionButton.vue";
+import CourseCredits from "../plugins/credits/CourseCredits.vue";
+import MissionCredits from "../plugins/credits/MissionCredits.vue";
 import SessionSchedule from "./components/SessionSchedule.vue";
 import VideoLibrary from "./components/VideoLibrary.vue";
 import WorkshopsPage from "./components/WorkshopsPage.vue";
@@ -40,6 +42,8 @@ export default {
     app.component("analytics-tag", AnalyticsTag);
     app.component("download-files", DownloadFiles);
     app.component("action-button", ActionButton);
+    app.component("course-credits", CourseCredits);
+    app.component("mission-credits", MissionCredits);
     app.component("SessionSchedule", SessionSchedule);
     app.component("VideoLibrary", VideoLibrary);
     app.component("WorkshopsPage", WorkshopsPage);

--- a/docs/recruit-nextgen/00-course-setup/index.md
+++ b/docs/recruit-nextgen/00-course-setup/index.md
@@ -22,7 +22,7 @@ products:
 industries:
   - it
 created-date: 2026-08-05
-last-edited-date: 2026-08-05
+last-edited-date: 2026-08-24
 ---
 
 # 🚨 Mission 00: Course Setup {#mission-00-course-setup}

--- a/docs/recruit-nextgen/00-course-setup/index.md
+++ b/docs/recruit-nextgen/00-course-setup/index.md
@@ -11,6 +11,7 @@ short-description: 'Set up your dev environment, Copilot Studio trial, and Share
 difficulty: 1
 codename: OPERATION DEPLOYMENT READY
 time: 30
+credits: 0
 tags:
   - setup
 products:
@@ -26,6 +27,8 @@ last-edited-date: 2026-08-05
 # 🚨 Mission 00: Course Setup {#mission-00-course-setup}
 
 <mission-meta />
+
+<mission-credits />
 
 ## 🎯 Mission Brief {#mission-brief}
 

--- a/docs/recruit-nextgen/01-introduction-to-agents/index.md
+++ b/docs/recruit-nextgen/01-introduction-to-agents/index.md
@@ -21,7 +21,7 @@ products:
 industries:
   - general
 created-date: 2026-08-05
-last-edited-date: 2026-08-05
+last-edited-date: 2026-08-24
 ---
 
 # 🚨 Mission 01: Introduction to Agents

--- a/docs/recruit-nextgen/01-introduction-to-agents/index.md
+++ b/docs/recruit-nextgen/01-introduction-to-agents/index.md
@@ -11,6 +11,7 @@ short-description: 'Learn how agents reason, use knowledge and tools, and operat
 difficulty: 1
 codename: OPERATION AI AGENT DECODE
 time: 15
+credits: 0
 tags:
   - fundamentals
 products:
@@ -25,6 +26,8 @@ last-edited-date: 2026-08-05
 # 🚨 Mission 01: Introduction to Agents
 
 <mission-meta />
+
+<mission-credits />
 
 ## 🎯 Mission Brief
 

--- a/docs/recruit-nextgen/02-copilot-studio-fundamentals/index.md
+++ b/docs/recruit-nextgen/02-copilot-studio-fundamentals/index.md
@@ -21,7 +21,7 @@ products:
 industries:
   - general
 created-date: 2026-08-05
-last-edited-date: 2026-08-05
+last-edited-date: 2026-08-24
 ---
 
 # 🛠️ Mission 02: Copilot Studio Fundamentals

--- a/docs/recruit-nextgen/02-copilot-studio-fundamentals/index.md
+++ b/docs/recruit-nextgen/02-copilot-studio-fundamentals/index.md
@@ -11,6 +11,7 @@ short-description: 'Explore Copilot Studio harnesses, agent building blocks, wor
 difficulty: 1
 codename: OPERATION TOOLBOX
 time: 20
+credits: 0
 tags:
   - fundamentals
 products:
@@ -25,6 +26,8 @@ last-edited-date: 2026-08-05
 # 🛠️ Mission 02: Copilot Studio Fundamentals
 
 <mission-meta />
+
+<mission-credits />
 
 ## 🎯 Mission Brief
 

--- a/docs/recruit-nextgen/03-creating-a-solution/index.md
+++ b/docs/recruit-nextgen/03-creating-a-solution/index.md
@@ -11,6 +11,7 @@ short-description: Package your agent into a reusable solution for environment m
 difficulty: 1
 codename: OPERATION CTRL-ALT-PACKAGE
 time: 45
+credits: 0
 tags:
   - solutions
 products:
@@ -24,6 +25,8 @@ last-edited-date: 2026-08-05
 # 🚨 Mission 03: Creating a Solution for Your Agent {#mission-03-creating-a-solution-for-your-agent}
 
 <mission-meta />
+
+<mission-credits />
 
 ## 🎯 Mission Brief {#mission-brief}
 

--- a/docs/recruit-nextgen/03-creating-a-solution/index.md
+++ b/docs/recruit-nextgen/03-creating-a-solution/index.md
@@ -21,7 +21,7 @@ products:
 industries:
   - it
 created-date: 2026-08-05
-last-edited-date: 2026-08-05
+last-edited-date: 2026-08-24
 ---
 # 🚨 Mission 03: Creating a Solution for Your Agent {#mission-03-creating-a-solution-for-your-agent}
 

--- a/docs/recruit-nextgen/04-build-a-custom-agent/index.md
+++ b/docs/recruit-nextgen/04-build-a-custom-agent/index.md
@@ -11,6 +11,7 @@ short-description: Create an agent powered by the GitHub Copilot harness using A
 difficulty: 1
 codename: OPERATION ENGINE SHIFT
 time: 60
+credits: [200, 600]
 tags: [fundamentals, solutions]
 products:
   - copilot-studio
@@ -25,6 +26,8 @@ last-edited-date: 2026-08-05
 # 🚨 Mission 04: Build an Agent with the GitHub Copilot Harness {#mission-04-build-an-agent-with-the-github-copilot-harness}
 
 <mission-meta />
+
+<mission-credits />
 
 > [!NOTE]
 > This lab builds an agent powered by the **GitHub Copilot harness**.
@@ -128,7 +131,7 @@ Before starting this lab, make sure you have:
 - Your test knowledge source(s), for example the **Contoso IT** SharePoint site from [Mission 00 - Course setup](../00-course-setup/index.md#step-5-create-new-sharepoint-site)
 
 > [!WARNING] Copilot Credit consumption starts during creation
-> Agents built with the **GitHub Copilot harness** use consumption-based billing. The natural-language authoring, Preview, and Evaluation experiences consume **Copilot Credits** while you build and test; manual configuration in the **Build** and **Monitor** tabs doesn't consume credits. See [Mission 09 - Understanding Licensing](../09-understanding-licensing/index.md) for more guidance and the [Microsoft Copilot Credits Guide](https://cdn-dynmedia-1.microsoft.com/is/content/microsoftcorp/microsoft/bade/documents/products-and-services/en-us/ai/Microsoft-Copilot-Credits-Guide-August-2026.pdf) for current details.
+> Agents built with the **GitHub Copilot harness** use consumption-based billing. The natural-language authoring, Preview, and Evaluation experiences consume **Copilot Credits** while you build and test; manual configuration in the **Build** and **Monitor** tabs doesn't consume credits. See [Mission 09 - Understanding Licensing](../09-understanding-licensing/index.md) for more guidance and the [Copilot Credits Guide](https://aka.ms/CopilotCredits/LicensingGuide) for current details.
 
 ### 4.1 Create a new agent with the GitHub Copilot harness
 
@@ -345,6 +348,37 @@ You can now:
 ✅ **Run baseline preview tests**: Verify the agent's core behavior before adding more capabilities.
 
 ⏭️ [Move to **Add Tools** mission](../05-add-tools/index.md)
+
+## 🪙 Copilot Credits Estimate {#copilot-credits-estimate}
+
+The **200 - 600 credits** shown at the top of this mission is a planning estimate, not a bill. Here's where the range comes from.
+
+The [Copilot Credits Guide](https://aka.ms/CopilotCredits/LicensingGuide) publishes the figures we used, and two of its statements shape this entire mission:
+
+- **No credits for manual configuration.** Work performed in the **Build** and **Monitor** tabs is free, so pasting instructions, connecting knowledge, configuring tools, and changing settings cost nothing.
+- **Preview and Evaluation bill at runtime rates.** The conversations you run yourself while testing cost the same as a real user's conversations.
+
+So this mission's cost is essentially the cost of the agent tasks you run in **Preview**. The guide bands runtime usage by how much work a task involves:
+
+| Agent scenario | Shape of the task | Est. credits |
+| -------------- | ----------------- | ------------ |
+| Light | Few sources, light reasoning, one or fewer outputs | 100 - 300 |
+| Medium | Many sources, structured reasoning, two or more outputs | 300 - 500 |
+| Heavy | Broad aggregation, deep reasoning, many outputs | 500+ |
+
+We classified every task this mission asks you to run, then added up the low and high ends of each band. That's why the estimate is a range rather than a single figure.
+
+| What you run | Classification | Est. credits |
+| ------------ | -------------- | ------------ |
+| Naming the agent, pasting instructions, adding four knowledge sources, and setting the greeting | Build-tab configuration | 0 |
+| Preview test: checking Surface warranty status | Light. One public website source, one answer | 100 - 300 |
+| Preview test: VPN access and Guest Wi-Fi details | Light. Grounded in SharePoint and the uploaded document, still a single answer | 100 - 300 |
+| **Total** | | **200 - 600** |
+
+Where you land inside that range depends on how much work each task turns out to be. Going **over** the top of the range is entirely possible: repeating a test, asking extra follow-up questions, or redoing a lab after a configuration mistake each add another task on top of the ones counted here.
+
+> [!IMPORTANT] Estimates aren't a commitment
+> These numbers apply the guide's published bands to the steps in this mission. They aren't measured in your tenant, and both rates and product behavior can change. Use them to decide how much credit capacity to have available before you start, not to predict an invoice. [Mission 09](../09-understanding-licensing/index.md) explains what drives consumption and how to monitor it.
 
 ## 📚 Tactical Resources {#tactical-resources}
 

--- a/docs/recruit-nextgen/04-build-a-custom-agent/index.md
+++ b/docs/recruit-nextgen/04-build-a-custom-agent/index.md
@@ -21,7 +21,7 @@ products:
 industries:
   - it
 created-date: 2026-08-05
-last-edited-date: 2026-08-05
+last-edited-date: 2026-08-24
 ---
 
 # 🚨 Mission 04: Build an Agent with the GitHub Copilot Harness {#mission-04-build-an-agent-with-the-github-copilot-harness}

--- a/docs/recruit-nextgen/05-add-tools/index.md
+++ b/docs/recruit-nextgen/05-add-tools/index.md
@@ -11,6 +11,7 @@ short-description: Add a SharePoint Get items tool so your agent can take action
 difficulty: 1
 codename: OPERATION TOOL UP
 time: 30
+credits: 0
 tags:
    - automation
    - grounding
@@ -27,6 +28,8 @@ last-edited-date: 2026-08-05
 # 🚨 Mission 05: Add a Tool {#mission-05-add-a-tool}
 
 <mission-meta />
+
+<mission-credits />
 
 > [!NOTE]
 > This lab uses an agent powered by the **GitHub Copilot harness**.

--- a/docs/recruit-nextgen/05-add-tools/index.md
+++ b/docs/recruit-nextgen/05-add-tools/index.md
@@ -22,7 +22,7 @@ products:
 industries:
   - it
 created-date: 2026-08-05
-last-edited-date: 2026-08-05
+last-edited-date: 2026-08-24
 
 ---
 

--- a/docs/recruit-nextgen/06-add-skills/index.md
+++ b/docs/recruit-nextgen/06-add-skills/index.md
@@ -11,6 +11,7 @@ short-description: Use a GitHub Copilot harness Skill to create a reusable devic
 difficulty: 1
 codename: OPERATION SKILL BOOST
 time: 30
+credits: [1000, 1800]
 tags:
     - custom-skills
     - instructions
@@ -27,6 +28,8 @@ last-edited-date: 2026-08-05
 # 🚨 Mission 06: Add Skills {#mission-06-add-skills}
 
 <mission-meta />
+
+<mission-credits />
 
 > [!NOTE]
 > **Skills are unique to agents powered by the GitHub Copilot harness** in Copilot Studio. They aren't available to agents powered by the standard or Copilot chat harness.
@@ -617,6 +620,39 @@ You can now:
 ✅ **Define reliable outcomes**: Add validation rules, escalation paths, and success criteria that improve consistency.
 
 ⏭️ [Move to **Automate with Workflows**](../07-automate-with-workflows/index.md) to get started.
+
+## 🪙 Copilot Credits Estimate {#copilot-credits-estimate}
+
+The **1,000 - 1,800 credits** shown at the top of this mission is a planning estimate, not a bill. Here's where the range comes from.
+
+The [Copilot Credits Guide](https://aka.ms/CopilotCredits/LicensingGuide) publishes the figures we used, and two of its statements shape this entire mission:
+
+- **No credits for manual configuration.** Work performed in the **Build** and **Monitor** tabs is free, so pasting instructions, connecting knowledge, configuring tools, and changing settings cost nothing.
+- **Preview and Evaluation bill at runtime rates.** The conversations you run yourself while testing cost the same as a real user's conversations.
+
+So this mission's cost is essentially the cost of the agent tasks you run in **Preview**. The guide bands runtime usage by how much work a task involves:
+
+| Agent scenario | Shape of the task | Est. credits |
+| -------------- | ----------------- | ------------ |
+| Light | Few sources, light reasoning, one or fewer outputs | 100 - 300 |
+| Medium | Many sources, structured reasoning, two or more outputs | 300 - 500 |
+| Heavy | Broad aggregation, deep reasoning, many outputs | 500+ |
+
+We classified every task this mission asks you to run, then added up the low and high ends of each band. That's why the estimate is a range rather than a single figure.
+
+| What you run | Classification | Est. credits |
+| ------------ | -------------- | ------------ |
+| Uploading the skill packages and editing instructions | Build-tab configuration | 0 |
+| First device guidance test, before the skill is refined | Light. One SharePoint tool call returning a device list | 100 - 300 |
+| Second device guidance test, including the device selection | Medium. Tool call plus a structured selection summary | 300 - 500 |
+| Third device guidance test, including the additional requirement | Medium. Tool call plus a summary that carries the extra requirement | 300 - 500 |
+| Troubleshooting skill test in step 6.2 | Medium. Four turns of structured, knowledge-grounded diagnosis | 300 - 500 |
+| **Total** | | **1,000 - 1,800** |
+
+Where you land inside that range depends on how much work each task turns out to be. Going **over** the top of the range is entirely possible: repeating a test, asking extra follow-up questions, or redoing a lab after a configuration mistake each add another task on top of the ones counted here.
+
+> [!IMPORTANT] Estimates aren't a commitment
+> These numbers apply the guide's published bands to the steps in this mission. They aren't measured in your tenant, and both rates and product behavior can change. Use them to decide how much credit capacity to have available before you start, not to predict an invoice. [Mission 09](../09-understanding-licensing/index.md) explains what drives consumption and how to monitor it.
 
 ## 📚 Tactical Resources {#tactical-resources}
 

--- a/docs/recruit-nextgen/06-add-skills/index.md
+++ b/docs/recruit-nextgen/06-add-skills/index.md
@@ -22,7 +22,7 @@ products:
 industries:
   - it
 created-date: 2026-08-05
-last-edited-date: 2026-08-05
+last-edited-date: 2026-08-24
 
 ---
 

--- a/docs/recruit-nextgen/07-automate-with-workflows/index.md
+++ b/docs/recruit-nextgen/07-automate-with-workflows/index.md
@@ -11,6 +11,7 @@ short-description: Automate a device request with a workflow and call it from yo
 difficulty: 1
 codename: OPERATION AUTOMATION POWERHOUSE
 time: 60
+credits: [700, 1300]
 tags:
   - automation
   - triggers
@@ -25,6 +26,8 @@ last-edited-date: 2026-08-05
 # 🚨 Mission 07: Automate with Workflows {#mission-07-automate-with-workflows}
 
 <mission-meta />
+
+<mission-credits />
 
 > [!NOTE]
 > This lab uses an agent and workflows powered by the **GitHub Copilot harness**.
@@ -668,6 +671,38 @@ You can now:
 ✅ **Test workflow paths**: Validate requests with additional requirements, without additional requirements, and with cancellation.
 
 ⏭️ [Move to **Publish your agent** mission](../08-publish-your-agent/index.md)
+
+## 🪙 Copilot Credits Estimate {#copilot-credits-estimate}
+
+The **700 - 1,300 credits** shown at the top of this mission is a planning estimate, not a bill. Here's where the range comes from.
+
+The [Copilot Credits Guide](https://aka.ms/CopilotCredits/LicensingGuide) publishes the figures we used, and two of its statements shape this entire mission:
+
+- **No credits for manual configuration.** Work performed in the **Build** and **Monitor** tabs is free, so pasting instructions, connecting knowledge, configuring tools, and changing settings cost nothing.
+- **Preview and Evaluation bill at runtime rates.** The conversations you run yourself while testing cost the same as a real user's conversations.
+
+So this mission's cost is essentially the cost of the agent tasks you run in **Preview**. The guide bands runtime usage by how much work a task involves:
+
+| Agent scenario | Shape of the task | Est. credits |
+| -------------- | ----------------- | ------------ |
+| Light | Few sources, light reasoning, one or fewer outputs | 100 - 300 |
+| Medium | Many sources, structured reasoning, two or more outputs | 300 - 500 |
+| Heavy | Broad aggregation, deep reasoning, many outputs | 500+ |
+
+We classified every task this mission asks you to run, then added up the low and high ends of each band. That's why the estimate is a range rather than a single figure.
+
+| What you run | Classification | Est. credits |
+| ------------ | -------------- | ------------ |
+| Building the workflow in the designer and adding it as a tool | Build-tab configuration | 0 |
+| Test one: device request with additional requirements | Medium. Runs the workflow, reads SharePoint, and sends an email | 300 - 500 |
+| Test two: device request with no additional requirements | Medium. Same workflow path, different branch | 300 - 500 |
+| Test three: cancelling the request | Light. The agent ends the session without running the workflow | 100 - 300 |
+| **Total** | | **700 - 1,300** |
+
+Where you land inside that range depends on how much work each task turns out to be. Going **over** the top of the range is entirely possible: repeating a test, asking extra follow-up questions, or redoing a lab after a configuration mistake each add another task on top of the ones counted here.
+
+> [!IMPORTANT] Estimates aren't a commitment
+> These numbers apply the guide's published bands to the steps in this mission. They aren't measured in your tenant, and both rates and product behavior can change. Use them to decide how much credit capacity to have available before you start, not to predict an invoice. [Mission 09](../09-understanding-licensing/index.md) explains what drives consumption and how to monitor it.
 
 ## 📚 Tactical Resources {#tactical-resources}
 

--- a/docs/recruit-nextgen/07-automate-with-workflows/index.md
+++ b/docs/recruit-nextgen/07-automate-with-workflows/index.md
@@ -20,7 +20,7 @@ products: [copilot-studio, power-automate, outlook, sharepoint]
 industries:
   - it
 created-date: 2026-08-05
-last-edited-date: 2026-08-05
+last-edited-date: 2026-08-24
 
 ---
 

--- a/docs/recruit-nextgen/08-publish-your-agent/index.md
+++ b/docs/recruit-nextgen/08-publish-your-agent/index.md
@@ -22,7 +22,7 @@ products:
 industries:
   - it
 created-date: 2026-08-05
-last-edited-date: 2026-08-05
+last-edited-date: 2026-08-24
 ---
 
 # 🚨 Mission 08: Publish Your Agent {#mission-08-publish-your-agent}

--- a/docs/recruit-nextgen/08-publish-your-agent/index.md
+++ b/docs/recruit-nextgen/08-publish-your-agent/index.md
@@ -11,6 +11,7 @@ short-description: 'Publish your agent'
 difficulty: 1
 codename: OPERATION ROLL OUT
 time: 15
+credits: [200, 600]
 tags:
   - publishing
 products:
@@ -26,6 +27,8 @@ last-edited-date: 2026-08-05
 # 🚨 Mission 08: Publish Your Agent {#mission-08-publish-your-agent}
 
 <mission-meta />
+
+<mission-credits />
 
 ## 🎯 Mission Brief {#mission-brief}
 
@@ -202,6 +205,37 @@ You can now:
 ✅ **Validate the employee experience**: Install and test the published agent in Teams and Microsoft 365 Copilot
 
 ⏭️ [Move to **Understanding Licensing**](../09-understanding-licensing/index.md) to learn how GitHub Copilot harness usage is billed and managed.
+
+## 🪙 Copilot Credits Estimate {#copilot-credits-estimate}
+
+The **200 - 600 credits** shown at the top of this mission is a planning estimate, not a bill. Here's where the range comes from.
+
+The [Copilot Credits Guide](https://aka.ms/CopilotCredits/LicensingGuide) publishes the figures we used, and two of its statements shape this entire mission:
+
+- **No credits for manual configuration.** Work performed in the **Build** and **Monitor** tabs is free, so pasting instructions, connecting knowledge, configuring tools, and changing settings cost nothing.
+- **Preview and Evaluation bill at runtime rates.** The conversations you run yourself while testing cost the same as a real user's conversations.
+
+So this mission's cost is essentially the cost of the agent tasks you run in **Preview**. The guide bands runtime usage by how much work a task involves:
+
+| Agent scenario | Shape of the task | Est. credits |
+| -------------- | ----------------- | ------------ |
+| Light | Few sources, light reasoning, one or fewer outputs | 100 - 300 |
+| Medium | Many sources, structured reasoning, two or more outputs | 300 - 500 |
+| Heavy | Broad aggregation, deep reasoning, many outputs | 500+ |
+
+We classified every task this mission asks you to run, then added up the low and high ends of each band. That's why the estimate is a range rather than a single figure.
+
+| What you run | Classification | Est. credits |
+| ------------ | -------------- | ------------ |
+| Publishing the agent and configuring channels | Build-tab configuration | 0 |
+| Teams test in step 8.2 | Light. One troubleshooting request | 100 - 300 |
+| Microsoft 365 Copilot test in step 8.3 | Light. One troubleshooting request | 100 - 300 |
+| **Total** | | **200 - 600** |
+
+Where you land inside that range depends on how much work each task turns out to be. Going **over** the top of the range is entirely possible: repeating a test, asking extra follow-up questions, or redoing a lab after a configuration mistake each add another task on top of the ones counted here.
+
+> [!IMPORTANT] Estimates aren't a commitment
+> These numbers apply the guide's published bands to the steps in this mission. They aren't measured in your tenant, and both rates and product behavior can change. Use them to decide how much credit capacity to have available before you start, not to predict an invoice. [Mission 09](../09-understanding-licensing/index.md) explains what drives consumption and how to monitor it.
 
 ## 📚 Tactical Resources {#tactical-resources}
 

--- a/docs/recruit-nextgen/09-understanding-licensing/index.md
+++ b/docs/recruit-nextgen/09-understanding-licensing/index.md
@@ -21,7 +21,7 @@ products:
 industries:
   - it
 created-date: 2026-08-05
-last-edited-date: 2026-08-05
+last-edited-date: 2026-08-24
 ---
 
 # 🚨 Mission 09: Understanding Licensing {#mission-09-understanding-licensing}

--- a/docs/recruit-nextgen/09-understanding-licensing/index.md
+++ b/docs/recruit-nextgen/09-understanding-licensing/index.md
@@ -11,6 +11,7 @@ short-description: Learn how licensing and usage-based billing work for the GitH
 difficulty: 1
 codename: OPERATION KNOW WHAT YOU OWE
 time: 20
+credits: 0
 tags:
   - licensing
 products:
@@ -26,6 +27,8 @@ last-edited-date: 2026-08-05
 
 <mission-meta />
 
+<mission-credits />
+
 ## 🎯 Mission Brief {#mission-brief}
 
 You've built and published the `Contoso IT Concierge`. Now it's time to step back from building and consider what operating it could mean for your organization.
@@ -37,7 +40,7 @@ The agent and workflow in this course use the **GitHub Copilot harness**. That m
 By the end, you'll be able to explain why harness choice affects billing, recognize the activities and design choices that drive usage, and discuss funding and monitoring with your platform administrators. You won't calculate a production budget or memorize rates.
 
 > [!IMPORTANT] Use the current guide as the source of truth
-> Licensing, rates, purchase options, and included entitlements can change. Use the [Microsoft Copilot Credits Guide - August 2026](https://cdn-dynmedia-1.microsoft.com/is/content/microsoftcorp/microsoft/bade/documents/products-and-services/en-us/ai/Microsoft-Copilot-Credits-Guide-August-2026.pdf) and applicable Microsoft Product Terms when making real licensing decisions. This mission explains the concepts; it doesn't replace those sources or advice from your Microsoft account team or partner.
+> Licensing, rates, purchase options, and included entitlements can change. Use the [Copilot Credits Guide](https://aka.ms/CopilotCredits/LicensingGuide) and applicable Microsoft Product Terms when making real licensing decisions. This mission explains the concepts; it doesn't replace those sources or advice from your Microsoft account team or partner.
 
 ## 🔎 Objectives {#objectives}
 
@@ -138,7 +141,7 @@ You can now:
 
 ## 📚 Tactical Resources {#tactical-resources}
 
-- 📘 [Microsoft Copilot Credits Guide - August 2026](https://cdn-dynmedia-1.microsoft.com/is/content/microsoftcorp/microsoft/bade/documents/products-and-services/en-us/ai/Microsoft-Copilot-Credits-Guide-August-2026.pdf)
+- 📘 [Copilot Credits Guide](https://aka.ms/CopilotCredits/LicensingGuide)
 
 - 🧭 [Choose a harness in Copilot Studio](https://learn.microsoft.com/en-us/microsoft-copilot-studio/harnesses-overview)
 

--- a/docs/recruit-nextgen/course-completion-badges-recruit/index.md
+++ b/docs/recruit-nextgen/course-completion-badges-recruit/index.md
@@ -11,6 +11,7 @@ short-description: Claim your badge and mark your achievement!
 difficulty: 1
 codename: OPERATION COURSE COMPLETION
 time: 5
+credits: 0
 tags:
   - completion
 products:
@@ -23,6 +24,8 @@ last-edited-date: 2026-08-05
 # 🚨 Final Mission: Securing Your Recruit NextGen Badge {#final-mission-securing-your-recruit-nextgen-badge}
 
 <mission-meta />
+
+<mission-credits />
 
 ## 🎯 Mission Brief {#mission-brief}
 

--- a/docs/recruit-nextgen/course-completion-badges-recruit/index.md
+++ b/docs/recruit-nextgen/course-completion-badges-recruit/index.md
@@ -20,7 +20,7 @@ products:
 industries:
   - it
 created-date: 2026-08-05
-last-edited-date: 2026-08-05
+last-edited-date: 2026-08-24
 ---
 # 🚨 Final Mission: Securing Your Recruit NextGen Badge {#final-mission-securing-your-recruit-nextgen-badge}
 

--- a/docs/recruit-nextgen/index.md
+++ b/docs/recruit-nextgen/index.md
@@ -42,8 +42,11 @@ To complete all missions, you'll need:
 - **Copilot Credits** available in your tenant
 - Optional: Basic knowledge of SharePoint, Power Platform, or Power Fx
 
-> [!IMPORTANT] This path consumes Copilot Credits
-> Agents and workflows on the GitHub Copilot harness use **Copilot Credits** for usage-based billing during LLM-powered creation and runtime execution. The billing exception available to licensed Microsoft 365 Copilot users in authenticated employee scenarios doesn't apply here, so make sure your environment has credit capacity before you start. [Mission 09](/recruit-nextgen/09-understanding-licensing/) covers this in detail.
+<course-credits section="recruit-nextgen">
+
+Agents and workflows on the GitHub Copilot harness use **Copilot Credits** for usage-based billing during LLM-powered creation and runtime execution. The billing exception available to licensed Microsoft 365 Copilot users in authenticated employee scenarios doesn't apply here, so make sure your environment has credit capacity before you start. [Mission 09](/recruit-nextgen/09-understanding-licensing/) covers this in detail.
+
+</course-credits>
 
 The [Course Setup](/recruit-nextgen/00-course-setup/) mission walks you through getting these in place.
 


### PR DESCRIPTION
## Why

Learners starting the Recruit NextGen path had no way to know what it would cost them in Copilot Credits before they began. The GitHub Copilot harness bills usage-based, and the B2E billing exception for licensed Microsoft 365 Copilot users does not apply, so someone can get halfway through the path and run out of capacity. This adds an up-front, auditable estimate at both the mission and the course level.

## Approach

A new optional `credits` frontmatter field on missions holds a `[min, max]` range. Two new components render it:

- `<mission-credits />` sits directly under `<mission-meta />` on every mission and shows that mission's range in a callout box. Missions that consume credits link to their full breakdown; missions that are purely reading or Build-tab configuration say so explicitly.
- `<course-credits section="..." />` sums both ends of the range across a course and renders the same box on the course overview page. It accepts markdown slot content, which is how the "this path consumes Copilot Credits" explanation now lives inside the box rather than in a separate callout above it.

The plumbing goes through the existing `virtual:missions-data` Vite plugin, so the course total is derived from the mission frontmatter rather than hand-maintained.

## Where the numbers come from

Missions 04, 06, 07, and 08 each end with a `## Copilot Credits Estimate` section that shows the work. Two statements from the [Copilot Credits Guide](https://aka.ms/CopilotCredits/LicensingGuide) drive the whole model:

- Manual configuration in the Build and Monitor tabs consumes no credits.
- Preview and Evaluation bill at agent runtime rates.

So a mission's cost is essentially the cost of the agent tasks you run in Preview. Every such task is classified against the guide's published runtime bands (light 100-300, medium 300-500), and the low and high ends are summed. That is why the estimates are ranges. The course total lands at 2,100-4,300 credits.

## Worth a careful look

- **The classification is a judgment call.** The turn counts are read directly from the labs, and the bands are the published ones, but deciding whether a given Preview conversation is "light" or "medium" is my read, not a measurement. Nothing here has been validated against a real tenant. If you disagree with a row in one of the breakdown tables, the fix is a one-line edit plus the frontmatter range.
- **Mission 05 is deliberately 0.** Its lab is entirely Build-tab configuration with no test conversation at all.
- Two pre-existing links in Mission 09 pointed at a dated PDF URL; they now use the `aka.ms` short link along with the new references.
- `CONTRIBUTING-COURSES.md` documents the field and both components so future courses can adopt this.

This branch also carries an earlier unrelated commit, `Clarify harness and knowledge setup`, that was already sitting on it.

`npm run lint:md`, `npx cspell`, and `npm run docs:build` all pass.
